### PR TITLE
Feat/answer 정답 리스트 반환 구현

### DIFF
--- a/inpeak/build.gradle
+++ b/inpeak/build.gradle
@@ -59,6 +59,12 @@ dependencies {
         transitive = false  // 에이전트용 의존성 전이 비활성화
     }
     testImplementation "org.mockito:mockito-core:5.14.2"  // 테스트용 Mockito 코어
+
+    // QueryDsl, spring boot 3.x 이상 세팅
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 }
 
 // 테스트 태스크 설정
@@ -80,3 +86,19 @@ tasks.named('test', Test) {
         jvmArgs += "-javaagent:${configurations.mockitoAgent.singleFile}"  // Mockito 에이전트 추가
     }
 }
+
+// QueryDsl 빌드 옵션 (선택)
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory.set(file(querydslDir))
+}
+
+clean.doLast {
+    delete querydslDir
+}
+

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/Member.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/Member.java
@@ -1,0 +1,8 @@
+package com.blooming.inpeak.answer;
+
+import lombok.Getter;
+
+@Getter
+public class Member {
+    private Long Id;
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/Member.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/Member.java
@@ -1,8 +1,0 @@
-package com.blooming.inpeak.answer;
-
-import lombok.Getter;
-
-@Getter
-public class Member {
-    private Long Id;
-}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
@@ -1,15 +1,20 @@
 package com.blooming.inpeak.answer.controller;
 
-import com.blooming.inpeak.answer.controller.dto.request.AnswerSkipRequest;
+import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
+import com.blooming.inpeak.answer.dto.request.AnswerFilterRequest;
+import com.blooming.inpeak.answer.dto.request.AnswerSkipRequest;
+import com.blooming.inpeak.answer.dto.response.AnswerListResponse;
 import com.blooming.inpeak.answer.service.AnswerService;
 import com.blooming.inpeak.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,11 +24,20 @@ public class AnswerController {
     private final AnswerService answerService;
 
     @PostMapping("/skip")
-    private ResponseEntity<Void> skipAnswer(
+    public ResponseEntity<Void> skipAnswer(
         @AuthenticationPrincipal Member member,
         @RequestBody AnswerSkipRequest request
     ) {
         answerService.skipAnswer(member, request.questionId(), request.interviewId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/correct")
+    public ResponseEntity<AnswerListResponse> getCorrectAnswerList (
+        @AuthenticationPrincipal Member member,
+        AnswerFilterRequest request
+    ) {
+        AnswerFilterCommand command = request.toCommand(member);
+        return ResponseEntity.ok(answerService.getCorrectAnswerList(command));
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
@@ -1,8 +1,10 @@
 package com.blooming.inpeak.answer.controller;
 
+import com.blooming.inpeak.answer.Member;
 import com.blooming.inpeak.answer.controller.dto.request.AnswerSkipRequest;
 import com.blooming.inpeak.answer.service.AnswerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +24,6 @@ public class AnswerController {
         @RequestBody AnswerSkipRequest request
     ) {
         answerService.skipAnswer(member, request.questionId(), request.interviewId());
-
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
@@ -1,8 +1,8 @@
 package com.blooming.inpeak.answer.controller;
 
-import com.blooming.inpeak.answer.Member;
 import com.blooming.inpeak.answer.controller.dto.request.AnswerSkipRequest;
 import com.blooming.inpeak.answer.service.AnswerService;
+import com.blooming.inpeak.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
@@ -1,7 +1,7 @@
 package com.blooming.inpeak.answer.domain;
 
-import com.blooming.inpeak.answer.Member;
 import com.blooming.inpeak.common.base.AuditingFields;
+import com.blooming.inpeak.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
@@ -6,9 +6,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -34,6 +37,16 @@ public class Answer extends AuditingFields {
     @Column(nullable = false)
     private Long interviewId;
 
+    // 저장 시에는 사용되지 않고 값을 조회할 때만 사용되는 필드들 페치 조인을 위해 사용된다.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "questionId", insertable = false, updatable = false)
+    private Question question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interviewId", insertable = false, updatable = false)
+    private Interview interview;
+
+
     private String userAnswer;
 
     private String videoURL;
@@ -42,7 +55,6 @@ public class Answer extends AuditingFields {
 
     private String comment;
 
-    @Column(nullable = false)
     private boolean isUnderstood;
 
     @Column(nullable = false)
@@ -51,7 +63,7 @@ public class Answer extends AuditingFields {
 
     @Builder
     private Answer(Long questionId, Long memberId, Long interviewId, String userAnswer, String videoURL,
-        Long runningTime, String comment, boolean isUnderstood, AnswerStatus status) {
+        Long runningTime, String comment, Boolean isUnderstood, AnswerStatus status) {
         this.questionId = questionId;
         this.memberId = memberId;
         this.interviewId = interviewId;
@@ -69,7 +81,6 @@ public class Answer extends AuditingFields {
             .questionId(questionId)
             .memberId(member.getId())
             .interviewId(interviewId)
-            .isUnderstood(false) // 스킵된 답변은 이해 여부 false
             .status(AnswerStatus.SKIPPED) // 스킵된 상태 설정
             .build();
     }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
@@ -1,5 +1,6 @@
 package com.blooming.inpeak.answer.domain;
 
+import com.blooming.inpeak.answer.Member;
 import com.blooming.inpeak.common.base.AuditingFields;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Interview.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Interview.java
@@ -1,0 +1,16 @@
+package com.blooming.inpeak.answer.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Interview {
+
+    @Id
+    Long id;
+
+    LocalDateTime createdAt;
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Question.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Question.java
@@ -1,0 +1,14 @@
+package com.blooming.inpeak.answer.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Question {
+    @Id
+    Long id;
+
+    String title;
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/command/AnswerFilterCommand.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/command/AnswerFilterCommand.java
@@ -1,0 +1,17 @@
+package com.blooming.inpeak.answer.dto.command;
+
+import com.blooming.inpeak.member.domain.Member;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record AnswerFilterCommand(
+    Member member,
+
+    String sortType,
+
+    boolean isUnderstood,
+
+    int page
+) { }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/AnswerFilterRequest.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/AnswerFilterRequest.java
@@ -1,0 +1,24 @@
+package com.blooming.inpeak.answer.dto.request;
+
+import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
+import com.blooming.inpeak.member.domain.Member;
+import jakarta.validation.constraints.*;
+
+public record AnswerFilterRequest(
+    @NotNull
+    String sortType,
+    @NotNull
+    boolean isUnderstood,
+    @Min(0)
+    @NotNull
+    int page
+) {
+    public AnswerFilterCommand toCommand(Member member) {
+        return AnswerFilterCommand.builder()
+            .member(member)
+            .isUnderstood(isUnderstood)
+            .sortType(sortType)
+            .page(page)
+            .build();
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/AnswerSkipRequest.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/AnswerSkipRequest.java
@@ -1,4 +1,4 @@
-package com.blooming.inpeak.answer.controller.dto.request;
+package com.blooming.inpeak.answer.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/AnswerListResponse.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/AnswerListResponse.java
@@ -1,0 +1,8 @@
+package com.blooming.inpeak.answer.dto.response;
+
+import java.util.List;
+
+public record AnswerListResponse(
+    List<AnswerResponse> AnswerResponseList,
+    boolean hasNext
+) { }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/AnswerResponse.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/AnswerResponse.java
@@ -1,0 +1,25 @@
+package com.blooming.inpeak.answer.dto.response;
+
+import com.blooming.inpeak.answer.domain.Answer;
+import com.blooming.inpeak.answer.domain.AnswerStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record AnswerResponse(
+    LocalDateTime dateTime,
+    String questionTitle,
+    Long runningTime,
+    AnswerStatus answerStatus,
+    boolean isUnderstood
+) {
+    public static AnswerResponse from (Answer answer) {
+        return AnswerResponse.builder()
+            .dateTime(answer.getInterview().getCreatedAt())  // 답변 작성 시간
+            .questionTitle(answer.getQuestion().getTitle())  // 질문 제목
+            .runningTime(answer.getRunningTime())  // 실행 시간
+            .answerStatus(answer.getStatus())  // 답변 상태
+            .isUnderstood(answer.isUnderstood())  // 이해 여부
+            .build();
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/repository/AnswerRepositoryCustom.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/repository/AnswerRepositoryCustom.java
@@ -1,0 +1,88 @@
+package com.blooming.inpeak.answer.repository;
+
+import com.blooming.inpeak.answer.domain.Answer;
+import com.blooming.inpeak.answer.domain.AnswerStatus;
+import com.blooming.inpeak.answer.domain.QAnswer;
+import com.blooming.inpeak.answer.domain.QInterview;
+import com.blooming.inpeak.answer.domain.QQuestion;
+import com.blooming.inpeak.member.domain.Member;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AnswerRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 정답 답변 리스트를 동적으로 조회하는 메서드
+     *
+     * @param member 사용자 객체
+     * @param isUnderstood 이해 여부
+     * @param sortType 정렬 조건
+     * @param pageable 페이징 정보
+     * @return question, interview까지 페치 조인하여 전체 답변 리스트를 반환
+     */
+    public Slice<Answer> findCorrectAnswerList (
+        Member member,
+        boolean isUnderstood,
+        String sortType,
+        Pageable pageable
+    ) {
+        QAnswer answer = QAnswer.answer;
+        QQuestion question = QQuestion.question;
+        QInterview interview = QInterview.interview;
+
+        // isUnderstood가 true일 경우에만 필터 적용
+        BooleanExpression understoodFilter = isUnderstood
+            ? answer.isUnderstood.eq(true) : null;
+
+        // member 조건 추가
+        BooleanExpression memberFilter = answer.memberId.eq(member.getId());
+
+        // AnswerStatus가 CORRECT인 조건 추가
+        BooleanExpression statusFilter = answer.status.eq(AnswerStatus.CORRECT);
+
+        //동적 정렬 조건 적용
+        OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sortType, answer);
+
+        List<Answer> results = queryFactory
+            .selectFrom(answer)
+            .leftJoin(question).on(answer.questionId.eq(question.id)).fetchJoin()
+            .leftJoin(interview).on(answer.interviewId.eq(interview.id)).fetchJoin()
+            .where(understoodFilter, memberFilter, statusFilter)
+            .orderBy(orderSpecifier)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        // 추가로 가져온 항목이 있으면 다음 페이지가 있음
+        boolean hasNext = results.size() > pageable.getPageSize();
+        if (hasNext) {
+            results.remove(results.size() - 1); // 추가로 가져온 항목 제거
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(String sortType, QAnswer answer) {
+        if ("ASC".equalsIgnoreCase(sortType)) {
+            return answer.createdAt.asc();
+        }
+        else if ("DESC".equalsIgnoreCase(sortType)) {
+            return answer.createdAt.desc();
+        }
+        else {
+            throw new IllegalArgumentException("올바르지 않은 정렬 타입입니다: " + sortType);
+        }
+    }
+
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
@@ -1,15 +1,24 @@
 package com.blooming.inpeak.answer.service;
 
 import com.blooming.inpeak.answer.domain.Answer;
+import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
+import com.blooming.inpeak.answer.dto.response.AnswerListResponse;
+import com.blooming.inpeak.answer.dto.response.AnswerResponse;
 import com.blooming.inpeak.answer.repository.AnswerRepository;
+import com.blooming.inpeak.answer.repository.AnswerRepositoryCustom;
 import com.blooming.inpeak.member.domain.Member;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AnswerService {
     private final AnswerRepository answerRepository;
+    private final AnswerRepositoryCustom answerRepositoryCustom;
 
     /**
      * 답변을 스킵하는 메서드
@@ -21,5 +30,29 @@ public class AnswerService {
     public void skipAnswer(Member member, Long questionId, Long interviewId) {
         Answer skippedAnswer = Answer.ofSkipped(member, questionId, interviewId);
         answerRepository.save(skippedAnswer);
+    }
+
+    /**
+     * 사용자 답변 중 정답인 데이터만 반환하는 메서드
+     *
+     * @param command 사용자 정보와 검색 조건을 담은 command
+     * @return 정답인 답변을 담은 리스트와 다음 페이지가 있는 지 여부를 반환
+     */
+    public AnswerListResponse getCorrectAnswerList(AnswerFilterCommand command) {
+        Pageable pageable = PageRequest.of(command.page(), 5);
+
+        Slice<Answer> results = answerRepositoryCustom
+            .findCorrectAnswerList(
+                command.member(),
+                command.isUnderstood(),
+                command.sortType(),
+                pageable
+            );
+
+        List<AnswerResponse> answerResponses = results.getContent().stream()
+            .map(AnswerResponse::from)
+            .toList();
+
+        return new AnswerListResponse(answerResponses, results.hasNext());
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
@@ -1,5 +1,6 @@
 package com.blooming.inpeak.answer.service;
 
+import com.blooming.inpeak.answer.Member;
 import com.blooming.inpeak.answer.domain.Answer;
 import com.blooming.inpeak.answer.repository.AnswerRepository;
 import lombok.RequiredArgsConstructor;

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
@@ -1,8 +1,8 @@
 package com.blooming.inpeak.answer.service;
 
-import com.blooming.inpeak.answer.Member;
 import com.blooming.inpeak.answer.domain.Answer;
 import com.blooming.inpeak.answer.repository.AnswerRepository;
+import com.blooming.inpeak.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/inpeak/src/main/java/com/blooming/inpeak/common/config/queryDSL/QuerydslConfig.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/config/queryDSL/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.blooming.inpeak.common.config.queryDSL;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/common/error/ErrorHandlingController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/error/ErrorHandlingController.java
@@ -29,4 +29,11 @@ public class ErrorHandlingController {
         ErrorResponse.FieldError fieldError = new ErrorResponse.FieldError(e.getPropertyName(), (String) e.getValue(), e.getMessage());
         return buildFieldErrors(ErrorCode.INPUT_VALUE_INVALID, List.of(fieldError));
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected ErrorResponse handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("올바르지 않은 요청 값이 전달되었습니다. " + e.getMessage());
+        return buildError(ErrorCode.INPUT_VALUE_INVALID);
+    }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
@@ -6,15 +6,18 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.util.Collection;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
 @Getter
 @Table(name = "members")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,4 +34,24 @@ public class Member {
 
     @Column
     private Long correctAnswerCount;
+
+    // 테스트용 임시 생성자. 나중에 생성자 만들때 삭제하셔도 됩니다.
+    public Member (Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
 }

--- a/inpeak/src/test/java/com/blooming/inpeak/answer/domain/AnswerTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/answer/domain/AnswerTest.java
@@ -1,0 +1,30 @@
+package com.blooming.inpeak.answer.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.blooming.inpeak.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AnswerTest {
+
+    @DisplayName("스킵된 답변 생성 테스트")
+    @Test
+    void ofSkipped() {
+        //given
+        Member member = new Member(1L);
+        Long questionId = 100L;
+        Long interviewId = 200L;
+
+        //when
+        Answer skippedAnswer = Answer.ofSkipped(member, questionId, interviewId);
+
+        //then
+        assertNotNull(skippedAnswer);
+        assertEquals(questionId, skippedAnswer.getQuestionId());
+        assertEquals(member.getId(), skippedAnswer.getMemberId());
+        assertEquals(interviewId, skippedAnswer.getInterviewId());
+        assertFalse(skippedAnswer.isUnderstood()); // 스킵된 답변은 이해 여부가 false
+        assertEquals(AnswerStatus.SKIPPED, skippedAnswer.getStatus()); // 스킵된 상태 설정
+    }
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/answer/domain/AnswerTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/answer/domain/AnswerTest.java
@@ -24,7 +24,6 @@ class AnswerTest {
         assertEquals(questionId, skippedAnswer.getQuestionId());
         assertEquals(member.getId(), skippedAnswer.getMemberId());
         assertEquals(interviewId, skippedAnswer.getInterviewId());
-        assertFalse(skippedAnswer.isUnderstood()); // 스킵된 답변은 이해 여부가 false
         assertEquals(AnswerStatus.SKIPPED, skippedAnswer.getStatus()); // 스킵된 상태 설정
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈

> ex) close #14

## 📝 작업 내용

> 임시 엔티티 생성 및 queryDSL을 이용한 동적 쿼리 구현

## 🎸 기타 (선택)
> 고려해야 하는 내용을 작성해 주세요.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> answer에 조회 전용 필드 추가했습니다 이거 좋은 거 같아요
