### PR TITLE
feat: Spring Security 기본 설정 적용 (#17)

### DIFF
--- a/inpeak/build.gradle
+++ b/inpeak/build.gradle
@@ -18,9 +18,6 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor  // Lombok 등의 애노테이션 프로세서 설정
     }
-    mockitoAgent {
-        transitive = false  // Mockito 에이전트의 전이적 의존성 비활성화
-    }
 }
 
 // 의존성을 가져올 저장소 설정
@@ -34,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     // 개발 도구 및 유틸리티
     compileOnly 'org.projectlombok:lombok'
@@ -54,37 +52,21 @@ dependencies {
     testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'  // 테스트용 Redis
     testRuntimeOnly 'com.h2database:h2'  // 테스트용 H2 데이터베이스
 
-    // Mockito 테스트 프레임워크 설정
-    mockitoAgent ("org.mockito:mockito-core:5.14.2") {
-        transitive = false  // 에이전트용 의존성 전이 비활성화
-    }
-    testImplementation "org.mockito:mockito-core:5.14.2"  // 테스트용 Mockito 코어
-
     // QueryDsl, spring boot 3.x 이상 세팅
     implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
     annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 // 테스트 태스크 설정
 tasks.named('test', Test) {
     useJUnitPlatform()  // JUnit 5 사용
-
-    // JVM 인자 설정
-    jvmArgs = [
-            '--enable-preview',  // 프리뷰 기능 활성화
-            '--add-opens=java.base/java.lang=ALL-UNNAMED',  // 모듈 접근 허용
-            '--add-opens=java.base/java.io=ALL-UNNAMED',
-            '--add-opens=java.base/java.util=ALL-UNNAMED',
-            '-XX:+EnableDynamicAgentLoading',  // 동적 에이전트 로딩 활성화
-            '-Xshare:off'  // 공유 클래스 캐시 비활성화
-    ]
-
-    // 테스트 실행 전 Mockito 에이전트 설정
-    doFirst {
-        jvmArgs += "-javaagent:${configurations.mockitoAgent.singleFile}"  // Mockito 에이전트 추가
-    }
 }
 
 // QueryDsl 빌드 옵션 (선택)
@@ -101,4 +83,3 @@ tasks.withType(JavaCompile).configureEach {
 clean.doLast {
     delete querydslDir
 }
-

--- a/inpeak/src/main/java/com/blooming/inpeak/HealthcheckController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/HealthcheckController.java
@@ -1,2 +1,14 @@
-package com.blooming.inpeak;public class HealthcheckController {
+package com.blooming.inpeak;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthcheckController {
+
+    @GetMapping("/healthcheck")
+    public ResponseEntity<Void> healthcheck() {
+        return ResponseEntity.ok().build();
+    }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/HealthcheckController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/HealthcheckController.java
@@ -1,0 +1,2 @@
+package com.blooming.inpeak;public class HealthcheckController {
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/common/config/SecurityConfig.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/config/SecurityConfig.java
@@ -1,0 +1,2 @@
+package com.blooming.inpeak.common.config;public class SecurityConfig {
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/common/config/SecurityConfig.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.blooming.inpeak.common.config;
 
-import java.util.Arrays;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,9 +7,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -21,7 +16,6 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
-            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
@@ -29,37 +23,5 @@ public class SecurityConfig {
             );
 
         return http.build();
-    }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-
-        configuration.setAllowedOriginPatterns(List.of("*"));
-
-        configuration.setAllowedHeaders(Arrays.asList(
-            "Authorization",
-            "Content-Type",
-            "Access-Control-Allow-Origin",
-            "Access-Control-Allow-Headers",
-            "Access-Control-Allow-Methods"
-        ));
-
-        // 필요한 HTTP 메서드 명시적 설정
-        configuration.setAllowedMethods(Arrays.asList(
-            "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"
-        ));
-
-        // Credentials 허용
-        configuration.setAllowCredentials(true);
-
-        // 노출할 헤더 설정
-        configuration.setExposedHeaders(Arrays.asList(
-            "Authorization", "Refresh-Token"
-        ));
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/common/config/SecurityConfig.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/config/SecurityConfig.java
@@ -1,2 +1,65 @@
-package com.blooming.inpeak.common.config;public class SecurityConfig {
+package com.blooming.inpeak.common.config;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().permitAll()
+            );
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOriginPatterns(List.of("*"));
+
+        configuration.setAllowedHeaders(Arrays.asList(
+            "Authorization",
+            "Content-Type",
+            "Access-Control-Allow-Origin",
+            "Access-Control-Allow-Headers",
+            "Access-Control-Allow-Methods"
+        ));
+
+        // 필요한 HTTP 메서드 명시적 설정
+        configuration.setAllowedMethods(Arrays.asList(
+            "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"
+        ));
+
+        // Credentials 허용
+        configuration.setAllowCredentials(true);
+
+        // 노출할 헤더 설정
+        configuration.setExposedHeaders(Arrays.asList(
+            "Authorization", "Refresh-Token"
+        ));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 }

--- a/inpeak/src/test/java/com/blooming/inpeak/common/config/SecurityConfigTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/common/config/SecurityConfigTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class SecurityConfigTest {
+  
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/common/config/SecurityConfigTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/common/config/SecurityConfigTest.java
@@ -1,4 +1,47 @@
-import static org.junit.jupiter.api.Assertions.*;
-class SecurityConfigTest {
-  
+package com.blooming.inpeak.common.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.blooming.inpeak.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityConfigTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @DisplayName("개발 환경에서 모든 엔드포인트 접근 가능 테스트")
+    @Test
+    void whenAccessingAnyEndpoint_thenReturns200() throws Exception {
+        mockMvc.perform(get("/healthcheck"))
+            .andExpect(status().isOk());
+    }
+
+    @DisplayName("존재하지 않는 경로는 404 응답을 반환해야 한다.")
+    @Test
+    void whenAccessingNonExistentPath_thenReturns404() throws Exception {
+        mockMvc.perform(get("/non-existent"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("CORS 설정 테스트")
+    void corsConfigurationTest() throws Exception {
+        mockMvc.perform(options("/healthcheck")
+                .header("Origin", "http://localhost:8080")
+                .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:8080"))
+                .andExpect(header().string("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,PATCH,OPTIONS"));
+    }
 }

--- a/inpeak/src/test/java/com/blooming/inpeak/common/config/SecurityConfigTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/common/config/SecurityConfigTest.java
@@ -1,8 +1,6 @@
 package com.blooming.inpeak.common.config;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.blooming.inpeak.IntegrationTestSupport;
@@ -32,16 +30,5 @@ class SecurityConfigTest extends IntegrationTestSupport {
     void whenAccessingNonExistentPath_thenReturns404() throws Exception {
         mockMvc.perform(get("/non-existent"))
             .andExpect(status().isNotFound());
-    }
-
-    @Test
-    @DisplayName("CORS 설정 테스트")
-    void corsConfigurationTest() throws Exception {
-        mockMvc.perform(options("/healthcheck")
-                .header("Origin", "http://localhost:8080")
-                .header("Access-Control-Request-Method", "GET"))
-                .andExpect(status().isOk())
-                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:8080"))
-                .andExpect(header().string("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,PATCH,OPTIONS"));
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #17 

## 📝 작업 내용
- Spring Security의 기본적인 보안 설정 적용

### 주요 변경 사항
- CSRF 비활성화 및 CORS 설정 추가
- Stateless한 세션 정책 적용
- 기본적으로 모든 요청을 허용하는 Security 설정 추가
- Healthcheck API 접근 허용 및 관련 테스트 작성
- PasswordEncoder Bean 제거 (Kakao OAuth만 사용)

### 테스트 방법
- `/healthcheck` 엔드포인트 접근 테스트
- CORS 설정이 올바르게 동작하는지 테스트
- 존재하지 않는 경로에 대한 404 응답 확인

## 💬 리뷰 요구사항(선택)
- [`SecurityConfig`](https://github.com/blooming-inpeak/inpeak-backend/compare/feat/%2317-spring-security-config?expand=1#diff-2e6f87bf6806ce90445c9a6f339a19b28c9d32dbeceee7fbf51a17d049f3367d) 설정이 괜찮은지 확인 부탁드립니다.
