### PR TITLE
feat: Interview 누적 연습 횟수, 잔여 기회 횟수 테스트 작성 (#24)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/interview/controller/InterviewController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/interview/controller/InterviewController.java
@@ -1,0 +1,9 @@
+package com.blooming.inpeak.interview.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class InterviewController {
+
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/interview/domain/InterviewTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/interview/domain/InterviewTest.java
@@ -1,0 +1,25 @@
+package com.blooming.inpeak.interview.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InterviewTest {
+
+    @Test
+    @DisplayName("인터뷰 엔티티 생성 테스트")
+    void createInterview() {
+        // given
+        Long memberId = 1L;
+        LocalDate startDate = LocalDate.now();
+
+        // when
+        Interview interview = Interview.of(memberId, startDate);
+
+        // then
+        assertThat(interview.getMemberId()).isEqualTo(memberId);
+        assertThat(interview.getStartDate()).isEqualTo(startDate);
+    }
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/interview/domain/InterviewTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/interview/domain/InterviewTest.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("Interview domain 테스트")
 class InterviewTest {
 
     @Test

--- a/inpeak/src/test/java/com/blooming/inpeak/interview/repository/InterviewRepositoryTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/interview/repository/InterviewRepositoryTest.java
@@ -8,15 +8,16 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
 
-@DataJpaTest
-class InterviewRepositoryTest {
+@DisplayName("InterviewRepository 테스트")
+class InterviewRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
     private InterviewRepository interviewRepository;
 
     @Test
+    @Transactional
     @DisplayName("회원의 인터뷰 개수를 조회하면 정확한 개수를 반환해야 한다.")
     void countByMemberId_ShouldReturnCorrectCount() {
         // given
@@ -32,6 +33,7 @@ class InterviewRepositoryTest {
     }
 
     @Test
+    @Transactional
     @DisplayName("회원이 특정 날짜에 인터뷰를 진행한 경우 true, 진행하지 않은 경우 false를 반환해야 한다.")
     void existsByMemberIdAndStartDate_ShouldReturnTrueIfExists() {
         // given
@@ -41,7 +43,8 @@ class InterviewRepositoryTest {
 
         // when
         boolean existsToday = interviewRepository.existsByMemberIdAndStartDate(memberId, today);
-        boolean existsYesterday = interviewRepository.existsByMemberIdAndStartDate(memberId, today.minusDays(1));
+        boolean existsYesterday = interviewRepository.existsByMemberIdAndStartDate(memberId,
+            today.minusDays(1));
 
         // then
         assertThat(existsToday).isTrue();

--- a/inpeak/src/test/java/com/blooming/inpeak/interview/repository/InterviewRepositoryTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/interview/repository/InterviewRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.blooming.inpeak.interview.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blooming.inpeak.IntegrationTestSupport;
+import com.blooming.inpeak.interview.domain.Interview;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class InterviewRepositoryTest {
+
+    @Autowired
+    private InterviewRepository interviewRepository;
+
+    @Test
+    @DisplayName("회원의 인터뷰 개수를 조회하면 정확한 개수를 반환해야 한다.")
+    void countByMemberId_ShouldReturnCorrectCount() {
+        // given
+        Long memberId = 1L;
+        interviewRepository.save(Interview.of(memberId, LocalDate.now()));
+        interviewRepository.save(Interview.of(memberId, LocalDate.now().minusDays(1)));
+
+        // when
+        long count = interviewRepository.countByMemberId(memberId);
+
+        // then
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("회원이 특정 날짜에 인터뷰를 진행한 경우 true, 진행하지 않은 경우 false를 반환해야 한다.")
+    void existsByMemberIdAndStartDate_ShouldReturnTrueIfExists() {
+        // given
+        Long memberId = 1L;
+        LocalDate today = LocalDate.now();
+        interviewRepository.save(Interview.of(memberId, today));
+
+        // when
+        boolean existsToday = interviewRepository.existsByMemberIdAndStartDate(memberId, today);
+        boolean existsYesterday = interviewRepository.existsByMemberIdAndStartDate(memberId, today.minusDays(1));
+
+        // then
+        assertThat(existsToday).isTrue();
+        assertThat(existsYesterday).isFalse();
+    }
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/interview/service/InterviewServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/interview/service/InterviewServiceTest.java
@@ -1,0 +1,69 @@
+package com.blooming.inpeak.interview.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.blooming.inpeak.interview.dto.response.RemainingInterviewsResponse;
+import com.blooming.inpeak.interview.dto.response.TotalInterviewsResponse;
+import com.blooming.inpeak.interview.repository.InterviewRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InterviewServiceTest {
+
+    @Mock
+    private InterviewRepository interviewRepository;
+
+    @InjectMocks
+    private InterviewService interviewService;
+
+    private static final Long MEMBER_ID = 1L;
+
+    @Test
+    @DisplayName("회원의 총 인터뷰 횟수를 조회하면 정확한 개수를 반환해야 한다.")
+    void getTotalInterviews_ShouldReturnCorrectCount() {
+        // given
+        when(interviewRepository.countByMemberId(MEMBER_ID)).thenReturn(5L);
+
+        // when
+        TotalInterviewsResponse response = interviewService.getTotalInterviews(MEMBER_ID);
+
+        // then
+        assertThat(response.totalCount()).isEqualTo(5);
+        verify(interviewRepository, times(1)).countByMemberId(MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("회원이 오늘 인터뷰를 진행하지 않았다면 남은 인터뷰 횟수는 1이어야 한다.")
+    void getRemainingInterviews_ShouldReturnOneIfNoInterviewToday() {
+        // given
+        when(interviewRepository.existsByMemberIdAndStartDate(MEMBER_ID, LocalDate.now())).thenReturn(false);
+
+        // when
+        RemainingInterviewsResponse response = interviewService.getRemainingInterviews(MEMBER_ID);
+
+        // then
+        assertThat(response.remainingInterviews()).isEqualTo(1);
+        verify(interviewRepository, times(1)).existsByMemberIdAndStartDate(MEMBER_ID, LocalDate.now());
+    }
+
+    @Test
+    @DisplayName("회원이 오늘 인터뷰를 이미 진행했다면 남은 인터뷰 횟수는 0이어야 한다.")
+    void getRemainingInterviews_ShouldReturnZeroIfInterviewToday() {
+        // given
+        when(interviewRepository.existsByMemberIdAndStartDate(MEMBER_ID, LocalDate.now())).thenReturn(true);
+
+        // when
+        RemainingInterviewsResponse response = interviewService.getRemainingInterviews(MEMBER_ID);
+
+        // then
+        assertThat(response.remainingInterviews()).isEqualTo(0);
+        verify(interviewRepository, times(1)).existsByMemberIdAndStartDate(MEMBER_ID, LocalDate.now());
+    }
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/interview/service/InterviewServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/interview/service/InterviewServiceTest.java
@@ -1,69 +1,66 @@
 package com.blooming.inpeak.interview.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
+import com.blooming.inpeak.IntegrationTestSupport;
+import com.blooming.inpeak.interview.domain.Interview;
 import com.blooming.inpeak.interview.dto.response.RemainingInterviewsResponse;
 import com.blooming.inpeak.interview.dto.response.TotalInterviewsResponse;
 import com.blooming.inpeak.interview.repository.InterviewRepository;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
-@ExtendWith(MockitoExtension.class)
-class InterviewServiceTest {
+@DisplayName("InterviewService 테스트")
+class InterviewServiceTest extends IntegrationTestSupport {
 
-    @Mock
+    @Autowired
     private InterviewRepository interviewRepository;
 
-    @InjectMocks
+    @Autowired
     private InterviewService interviewService;
 
     private static final Long MEMBER_ID = 1L;
 
     @Test
+    @Transactional
     @DisplayName("회원의 총 인터뷰 횟수를 조회하면 정확한 개수를 반환해야 한다.")
     void getTotalInterviews_ShouldReturnCorrectCount() {
         // given
-        when(interviewRepository.countByMemberId(MEMBER_ID)).thenReturn(5L);
+        interviewRepository.save(Interview.of(MEMBER_ID, LocalDate.now().minusDays(1)));
+        interviewRepository.save(Interview.of(MEMBER_ID, LocalDate.now().minusDays(2)));
 
         // when
         TotalInterviewsResponse response = interviewService.getTotalInterviews(MEMBER_ID);
 
         // then
-        assertThat(response.totalCount()).isEqualTo(5);
-        verify(interviewRepository, times(1)).countByMemberId(MEMBER_ID);
+        assertThat(response.totalCount()).isEqualTo(2);
     }
 
     @Test
+    @Transactional
     @DisplayName("회원이 오늘 인터뷰를 진행하지 않았다면 남은 인터뷰 횟수는 1이어야 한다.")
     void getRemainingInterviews_ShouldReturnOneIfNoInterviewToday() {
-        // given
-        when(interviewRepository.existsByMemberIdAndStartDate(MEMBER_ID, LocalDate.now())).thenReturn(false);
-
         // when
         RemainingInterviewsResponse response = interviewService.getRemainingInterviews(MEMBER_ID);
 
         // then
         assertThat(response.remainingInterviews()).isEqualTo(1);
-        verify(interviewRepository, times(1)).existsByMemberIdAndStartDate(MEMBER_ID, LocalDate.now());
     }
 
     @Test
+    @Transactional
     @DisplayName("회원이 오늘 인터뷰를 이미 진행했다면 남은 인터뷰 횟수는 0이어야 한다.")
     void getRemainingInterviews_ShouldReturnZeroIfInterviewToday() {
         // given
-        when(interviewRepository.existsByMemberIdAndStartDate(MEMBER_ID, LocalDate.now())).thenReturn(true);
+        interviewRepository.save(Interview.of(MEMBER_ID, LocalDate.now()));
 
         // when
         RemainingInterviewsResponse response = interviewService.getRemainingInterviews(MEMBER_ID);
 
         // then
         assertThat(response.remainingInterviews()).isEqualTo(0);
-        verify(interviewRepository, times(1)).existsByMemberIdAndStartDate(MEMBER_ID, LocalDate.now());
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈

close #24

## 📝 작업 내용
- Interview 테스트 코드 작성
  - `Interview.domain` - `of()`
  - `Interview.repository` - `countByMemberId()`
  - `Interview.repository` - `existsByMemberIdAndStartDate()`
  - `Interview.service` - `getTotalInterviews()`
  - `Interview.service` - `getRemainingInterviews()`

## 🎸 기타 (선택)
- Repository 테스트 시, Spring Boot 테스트 컨텍스트가 각각 새로 로드되는 상황 발생
  - 원인: `@DataJpaTest`는 기본적으로 테스트마다 새로운 컨텍스트를 로드함
  - 해결 방법: 공통 Config 별도 생성 후 적용

## 💬 리뷰 요구사항(선택)

- Interview는 QueryDSL 설정이 필요치 않습니다. -> 테스트에서 Spring Boot가 여러 번 뜨는 건 불가피한 상황일까요?
- `@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)`를 추가하는 방법이 있다고 하는데,
 실제 DB를 사용하기 때문에 좋은 방법은 아니라고 생각합니다.. 다른 대처법이 있을까요?