### PR TITLE
feat: 소셜 로그인 기능 구현 (#18, #19)

### DIFF
--- a/inpeak/.gitignore
+++ b/inpeak/.gitignore
@@ -8,6 +8,9 @@ build/
 ### Q Class ###
 src/main/generated
 
+### OAuth ###
+src/main/resources/application-oauth.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/domain/RefreshToken.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/domain/RefreshToken.java
@@ -1,0 +1,40 @@
+package com.blooming.inpeak.auth.domain;
+
+import com.blooming.inpeak.common.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "refreshtokens")
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private String refreshToken;
+
+    @Builder
+    private RefreshToken(Long memberId, String refreshToken) {
+        this.memberId = memberId;
+        this.refreshToken = refreshToken;
+    }
+
+    public void update(String newRefreshToken) {
+        this.refreshToken = newRefreshToken;
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/repository/RefreshTokenRepository.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.blooming.inpeak.auth.repository;
+
+import com.blooming.inpeak.auth.domain.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByMemberId(Long memberId);
+
+    Optional<RefreshToken> findByRefreshToken(String tokenValue);
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/service/CustomOAuth2UserService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,71 @@
+package com.blooming.inpeak.auth.service;
+
+import com.blooming.inpeak.common.utils.NicknameGenerator;
+import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.domain.OAuth2Provider;
+import com.blooming.inpeak.member.dto.MemberPrincipal;
+import com.blooming.inpeak.member.dto.OAuth2Command;
+import com.blooming.inpeak.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+    private final NicknameGenerator nicknameGenerator;
+
+    // 테스트를 위해 DefaultOAuth2UserService를 필드로 추가
+    private final DefaultOAuth2UserService defaultOAuth2UserService = new DefaultOAuth2UserService();
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 부모 클래스 메서드 호출 대신 필드 사용
+        OAuth2User oAuth2User = defaultOAuth2UserService.loadUser(userRequest);
+
+        try {
+            return processOAuth2User(userRequest, oAuth2User);
+        } catch (Exception e) {
+            throw new OAuth2AuthenticationException("소셜 로그인 처리 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration()
+            .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuth2Command oAuth2Command = OAuth2Command.of(provider, userNameAttributeName, oAuth2User.getAttributes());
+
+        String email = oAuth2Command.getEmail();
+        String accessToken = userRequest.getAccessToken().getTokenValue();
+
+        // 기존 회원 조회
+        Member member = memberRepository.findByEmail(email)
+            .orElseGet(() -> registerNewMember(email, accessToken, oAuth2Command.getProvider()));
+
+        return MemberPrincipal.create(member, oAuth2User.getAttributes());
+    }
+
+    private Member registerNewMember(String email, String accessToken, OAuth2Provider provider) {
+        String uniqueNickname = nicknameGenerator.generateUniqueNickname();
+
+        Member member = Member.builder()
+            .email(email)
+            .nickname(uniqueNickname)
+            .accessToken(accessToken)
+            .provider(provider)
+            .totalQuestionCount(0L)
+            .correctAnswerCount(0L)
+            .build();
+
+        return memberRepository.save(member);
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/common/config/SecurityConfig.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/config/SecurityConfig.java
@@ -1,26 +1,43 @@
 package com.blooming.inpeak.common.config;
 
+import com.blooming.inpeak.auth.service.CustomOAuth2UserService;
+import com.blooming.inpeak.handler.OAuth2AuthenticationSuccessHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler successHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
+            .httpBasic(HttpBasicConfigurer::disable)
             .sessionManagement(session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll()
-            );
+                .requestMatchers(
+                    "/api/public/**", "/**", "/oauth2/**", "/login/**", "/error"
+                )
+                .permitAll()
+                .anyRequest().authenticated())
+            .oauth2Login(oauth2 -> oauth2
+                .userInfoEndpoint(endpoint ->
+                    endpoint.userService(customOAuth2UserService))
+                .successHandler(successHandler));
+//            .addFilterBefore(); // filter 추가 (클래스로 추가)
 
         return http.build();
     }

--- a/inpeak/src/main/java/com/blooming/inpeak/common/utils/JwtTokenProvider.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/utils/JwtTokenProvider.java
@@ -1,0 +1,80 @@
+package com.blooming.inpeak.common.utils;
+
+import com.blooming.inpeak.member.domain.Member;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.issuer:inpeak}")
+    private String issuer;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String makeToken(Member member, Duration expiredAt) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expiredAt.toMillis());
+
+        return Jwts.builder()
+            .header()
+            .type("JWT")
+            .and()
+            .issuer(issuer)
+            .issuedAt(now)
+            .expiration(expiry)
+            .subject(String.valueOf(member.getId()))
+            .signWith(secretKey)
+            .compact();
+    }
+
+    /**
+     * 토큰에서 사용자 ID 추출
+     *
+     * @param token JWT 토큰
+     * @return 사용자 ID
+     */
+    public String getUserIdFromToken(String token) {
+        return Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getSubject();
+    }
+
+    /**
+     * 토큰 유효성 검증
+     *
+     * @param token 검증할 토큰
+     * @return 유효성 여부
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/common/utils/NicknameGenerator.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/utils/NicknameGenerator.java
@@ -1,0 +1,62 @@
+package com.blooming.inpeak.common.utils;
+
+import com.blooming.inpeak.member.repository.MemberRepository;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class NicknameGenerator {
+
+    private static final List<String> ADJECTIVES = Arrays.asList(
+        "행복한", "즐거운", "신나는", "활기찬", "용감한", "지혜로운", "영리한",
+        "친절한", "당당한", "귀여운", "멋진", "싱그러운", "힘찬", "열정적인"
+        // ... 더 많은 형용사 추가
+    );
+
+    private static final List<String> ACTIONS = Arrays.asList(
+        "뛰어가는", "춤추는", "노래하는", "웃고있는", "달리는", "산책하는",
+        "공부하는", "여행하는", "탐험하는", "생각하는", "그리는", "읽고있는"
+        // ... 더 많은 동작 추가
+    );
+
+    private static final List<String> ANIMALS = Arrays.asList(
+        "코끼리", "사자", "호랑이", "팬더", "고래", "독수리", "늑대", "여우",
+        "토끼", "기린", "곰", "펭귄", "돌고래", "부엉이", "캥거루", "고양이"
+        // ... 더 많은 동물 추가
+    );
+
+    private final MemberRepository memberRepository;
+    private final Random random = new SecureRandom();
+
+    private static final int NUMBER_RANGE = 9000;
+    private static final int NUMBER_START = 1000;
+
+    public String generateUniqueNickname() {
+        String nickname = generateNickname();
+
+        boolean result = memberRepository.existsByNickname(nickname);
+
+        if (result) {
+            log.info("닉네임 중복 발생. 다시 생성합니다.");
+            return generateUniqueNickname();
+        }
+
+        return nickname;
+    }
+
+    private String generateNickname() {
+        String action = ACTIONS.get(random.nextInt(ACTIONS.size()));
+        String adjective = ADJECTIVES.get(random.nextInt(ADJECTIVES.size()));
+        String animal = ANIMALS.get(random.nextInt(ANIMALS.size()));
+        int number = random.nextInt(NUMBER_RANGE) + NUMBER_START;
+
+        return String.format("%s %s %s %d", action, adjective, animal, number);
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/filter/TokenAuthenticationFilter.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/filter/TokenAuthenticationFilter.java
@@ -1,0 +1,8 @@
+package com.blooming.inpeak.filter;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter {
+
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,71 @@
+package com.blooming.inpeak.handler;
+
+import com.blooming.inpeak.auth.domain.RefreshToken;
+import com.blooming.inpeak.auth.repository.RefreshTokenRepository;
+import com.blooming.inpeak.common.utils.JwtTokenProvider;
+import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.dto.MemberPrincipal;
+import com.blooming.inpeak.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    public static String REDIRECT_URL = "http://localhost:8080/";
+    public static Duration ACCESS_TOKEN_DURATION = Duration.ofMinutes(30);
+    public static Duration REFRESH_TOKEN_DURATION = Duration.ofDays(14);
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void onAuthenticationSuccess(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Authentication authentication
+    ) throws IOException {
+
+        MemberPrincipal oAuth2User = (MemberPrincipal) authentication.getPrincipal();
+        String email = oAuth2User.getName();
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        String accessToken = jwtTokenProvider.makeToken(member, ACCESS_TOKEN_DURATION);
+        String refreshToken = jwtTokenProvider.makeToken(member, REFRESH_TOKEN_DURATION);
+
+        storeOrGenerate(member, refreshToken);
+
+        //리다이렉트 URL 생성, 차후에 쿠키 방식으로 리펙토링
+        String redirectUrl = ServletUriComponentsBuilder
+            .fromUriString(REDIRECT_URL)
+            .queryParam("accessToken", accessToken)
+            .queryParam("refreshToken", refreshToken)
+            .build()
+            .toUriString();
+
+        getRedirectStrategy()
+            .sendRedirect(request, response, redirectUrl);
+    }
+
+    private void storeOrGenerate(Member member, String refreshToken) {
+        RefreshToken refreshTokenInstance = refreshTokenRepository.findByMemberId(member.getId())
+            .orElse(
+                RefreshToken.builder()
+                    .memberId(member.getId())
+                    .refreshToken(refreshToken)
+                    .build()
+            );
+        refreshTokenInstance.update(refreshToken);
+        refreshTokenRepository.save(refreshTokenInstance);
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
@@ -1,7 +1,10 @@
 package com.blooming.inpeak.member.domain;
 
+import com.blooming.inpeak.common.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -18,14 +21,17 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Getter
 @Table(name = "members")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member implements UserDetails {
+public class Member extends BaseEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 15)
-    private String nickName;
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
 
     @Column(nullable = false, unique = true)
     private String accessToken;
@@ -36,18 +42,42 @@ public class Member implements UserDetails {
     @Column
     private Long correctAnswerCount;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OAuth2Provider provider;
+
     @Builder
-    private Member(String nickName, String accessToken) {
-        this.nickName = nickName;
+    private Member(
+        String email, String nickname, String accessToken,
+        Long totalQuestionCount, Long correctAnswerCount, OAuth2Provider provider
+    ) {
+        this.email = email;
+        this.nickname = nickname;
         this.accessToken = accessToken;
-        this.totalQuestionCount = 0L;
-        this.correctAnswerCount = 0L;
+        this.totalQuestionCount = totalQuestionCount;
+        this.correctAnswerCount = correctAnswerCount;
+        this.provider = provider;
     }
 
-    public static Member of(String nickName, String accessToken) {
+    // 테스트 파일에서 사용할 생성자
+    @Builder(access = AccessLevel.PRIVATE)
+    public Member(
+        Long id, String email, String nickname, String accessToken,
+        OAuth2Provider provider
+    ) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.accessToken = accessToken;
+        this.provider = provider;
+    }
+
+    public static Member of(String email, String nickname, String accessToken, OAuth2Provider provider) {
         return Member.builder()
-            .nickName(nickName)
+            .email(email)
+            .nickname(nickname)
             .accessToken(accessToken)
+            .provider(provider)
             .build();
     }
 
@@ -58,11 +88,11 @@ public class Member implements UserDetails {
 
     @Override
     public String getPassword() {
-        return null;
+        return null; // OAuth2 로그인이므로 패스워드 필요 없음
     }
 
     @Override
     public String getUsername() {
-        return null;
+        return email; // 사용자 식별자로 이메일 사용
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/OAuth2Provider.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/OAuth2Provider.java
@@ -1,0 +1,7 @@
+package com.blooming.inpeak.member.domain;
+
+public enum OAuth2Provider {
+    KAKAO,
+    GOOGLE,
+    NAVER
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/member/dto/MemberPrincipal.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/dto/MemberPrincipal.java
@@ -1,0 +1,64 @@
+package com.blooming.inpeak.member.dto;
+
+import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.domain.OAuth2Provider;
+import lombok.Builder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public record MemberPrincipal(
+    Long id,
+    String email,
+    String nickname,
+    OAuth2Provider provider,
+    Long totalQuestionCount,
+    Long correctAnswerCount,
+    Collection<? extends GrantedAuthority> authorities,
+    Map<String, Object> attributes
+) implements OAuth2User {
+
+    @Builder
+    public MemberPrincipal {
+    }
+
+    public static MemberPrincipal create(Member member, Map<String, Object> attributes) {
+        return MemberPrincipal.builder()
+            .id(member.getId())
+            .email(member.getEmail())
+            .nickname(member.getNickname())
+            .provider(member.getProvider())
+            .totalQuestionCount(member.getTotalQuestionCount())
+            .correctAnswerCount(member.getCorrectAnswerCount())
+            .authorities(Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")))
+            .attributes(attributes)
+            .build();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return email;
+    }
+
+    /**
+     * 특정 속성에 접근하기 위한 편의 메서드
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getAttribute(String name) {
+        return (T) attributes.get(name);
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/member/dto/OAuth2Command.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/dto/OAuth2Command.java
@@ -1,0 +1,68 @@
+package com.blooming.inpeak.member.dto;
+
+import com.blooming.inpeak.member.domain.OAuth2Provider;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuth2Command {
+
+    private String email;
+    private OAuth2Provider provider;
+
+    @Builder
+    private OAuth2Command(String email, OAuth2Provider provider) {
+        this.email = email;
+        this.provider = provider;
+    }
+
+    public static OAuth2Command of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        if ("kakao".equals(registrationId)) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+        if ("google".equals(registrationId)) {
+            return ofGoogle(userNameAttributeName, attributes);
+        }
+        if ("naver".equals(registrationId)) {
+            return ofNaver(userNameAttributeName, attributes);
+        }
+
+        throw new IllegalArgumentException("지원하지 않는 소셜 로그인 제공자입니다: " + registrationId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static OAuth2Command ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        String email = (String) kakaoAccount.get("email");
+
+        return OAuth2Command.builder()
+            .email(email)
+            .provider(OAuth2Provider.KAKAO)
+            .build();
+    }
+
+    private static OAuth2Command ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        String email = (String) attributes.get("email");
+
+        return OAuth2Command.builder()
+            .email(email)
+            .provider(OAuth2Provider.GOOGLE)
+            .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static OAuth2Command ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        String email = (String) response.get("email");
+
+        return OAuth2Command.builder()
+            .email(email)
+            .provider(OAuth2Provider.NAVER)
+            .build();
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/member/dto/OAuth2UserInfo.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/dto/OAuth2UserInfo.java
@@ -1,0 +1,24 @@
+package com.blooming.inpeak.member.dto;
+
+import com.blooming.inpeak.member.domain.OAuth2Provider;
+import java.util.Map;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public record OAuth2UserInfo(
+    String email,
+    OAuth2Provider provider
+) {
+    public static OAuth2UserInfo from(OAuth2User oauth2User, OAuth2Provider provider) {
+        Map<String, Object> attributes = oauth2User.getAttributes();
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
+        if (kakaoAccount == null || !kakaoAccount.containsKey("email")) {
+            throw new RuntimeException("카카오 계정에서 이메일을 가져올 수 없습니다.");
+        }
+
+        return new OAuth2UserInfo(
+            (String) kakaoAccount.get("email"),
+            provider
+        );
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/member/repository/MemberRepository.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.blooming.inpeak.member.repository;
+
+import com.blooming.inpeak.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+}

--- a/inpeak/src/main/resources/application.yml
+++ b/inpeak/src/main/resources/application.yml
@@ -4,13 +4,14 @@ spring:
       enabled: ALWAYS
   profiles:
     active: local
-#    include:
+    include:
 #      - aws
-#      - oauth
+      - oauth
 
-app:
-  token:
-    SECRET_KEY: ${SECRET_KEY:default_secret_key}
+jwt:
+  secret: ${SECRET_KEY:your-secret-key-should-be-at-least-32-characters-long}
+  expiration: ${EXPIRATION_TIME:86400000}
+  issuer: ${ISSUER:inpeak}
 
 ---
 spring:

--- a/inpeak/src/test/java/com/blooming/inpeak/DefaultSpringBootLoadingTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/DefaultSpringBootLoadingTest.java
@@ -2,6 +2,7 @@ package com.blooming.inpeak;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.blooming.inpeak.support.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/inpeak/src/test/java/com/blooming/inpeak/answer/repository/AnswerRepositoryCustomTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/answer/repository/AnswerRepositoryCustomTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.blooming.inpeak.answer.domain.Answer;
 import com.blooming.inpeak.answer.domain.AnswerStatus;
 import com.blooming.inpeak.interview.domain.Interview;
-import com.blooming.inpeak.question.domain.*;
+import com.blooming.inpeak.member.domain.OAuth2Provider;
+import com.blooming.inpeak.question.domain.Question;
+import com.blooming.inpeak.question.domain.QuestionType;
 import com.blooming.inpeak.common.config.queryDSL.QuerydslConfig;
 import com.blooming.inpeak.member.domain.Member;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -44,7 +46,14 @@ class AnswerRepositoryCustomTest {
     void setUp() {
         answerRepositoryCustom = new AnswerRepositoryCustom(queryFactory);
 
-        testMember = entityManager.persist(Member.of("testUser", "accessToken123"));
+        testMember = entityManager.persist(
+            Member.of(
+                "test@test.com",
+                "test",
+                "test",
+                OAuth2Provider.KAKAO
+            )
+        );
 
         // QuestionType을 명시적으로 설정하여 저장
         testQuestion = entityManager.persist(Question.of("테스트 질문", QuestionType.SPRING, "최고의 답변"));

--- a/inpeak/src/test/java/com/blooming/inpeak/auth/domain/RefreshTokenTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/auth/domain/RefreshTokenTest.java
@@ -1,0 +1,48 @@
+package com.blooming.inpeak.auth.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("RefreshToken 도메인 테스트")
+class RefreshTokenTest {
+
+    @DisplayName("RefreshToken 생성")
+    @Test
+    void createRefreshToken() {
+        // given
+        Long memberId = 1L;
+        String token = "test-refresh-token";
+
+        // when
+        RefreshToken refreshToken = RefreshToken.builder()
+            .memberId(memberId)
+            .refreshToken(token)
+            .build();
+
+        // then
+        assertThat(refreshToken.getMemberId()).isEqualTo(memberId);
+        assertThat(refreshToken.getRefreshToken()).isEqualTo(token);
+    }
+
+    @DisplayName("RefreshToken 업데이트")
+    @Test
+    void updateRefreshToken() {
+        // given
+        Long memberId = 1L;
+        RefreshToken refreshToken = RefreshToken.builder()
+            .memberId(memberId)
+            .refreshToken("old-refresh-token")
+            .build();
+
+        String newToken = "new-refresh-token";
+
+        // when
+        refreshToken.update(newToken);
+
+        // then
+        assertThat(refreshToken.getRefreshToken()).isEqualTo(newToken);
+    }
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/auth/repository/RefreshTokenRepositoryTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/auth/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.blooming.inpeak.auth.repository;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.blooming.inpeak.auth.domain.RefreshToken;
+import com.blooming.inpeak.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("RefreshTokenRepository 테스트")
+class RefreshTokenRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @DisplayName("memberId로 RefreshToken 조회")
+    @Test
+    void findByMemberId() {
+        // given
+        Long memberId = 1L;
+        RefreshToken token = RefreshToken.builder()
+            .memberId(memberId)
+            .refreshToken("test-token")
+            .build();
+        refreshTokenRepository.save(token);
+
+        // when
+        RefreshToken found = refreshTokenRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new IllegalStateException("해당 memberId의 RefreshToken이 존재하지 않습니다."));
+
+        // then
+        assertThat(found.getRefreshToken()).isEqualTo("test-token");
+    }
+
+    @DisplayName("refreshToken 값으로 엔티티 조회 성공")
+    @Test
+    void findByRefreshToken() {
+        // given
+        String tokenValue = "unique-token-value";
+        RefreshToken refreshToken = RefreshToken.builder()
+            .memberId(1L)
+            .refreshToken(tokenValue)
+            .build();
+        refreshTokenRepository.save(refreshToken);
+
+        // when
+        RefreshToken found = refreshTokenRepository.findByRefreshToken(tokenValue)
+            .orElseThrow(() -> new IllegalStateException("해당 refreshToken의 RefreshToken이 존재하지 않습니다."));
+
+        // then
+        assertThat(found.getRefreshToken()).isEqualTo(tokenValue);
+    }
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/auth/service/CustomOAuth2UserServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/auth/service/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,200 @@
+package com.blooming.inpeak.auth.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.blooming.inpeak.common.utils.NicknameGenerator;
+import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.domain.OAuth2Provider;
+import com.blooming.inpeak.member.dto.MemberPrincipal;
+import com.blooming.inpeak.member.repository.MemberRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("CustomOAuth2UserService 테스트")
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2UserServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private NicknameGenerator nicknameGenerator;
+
+    @Mock
+    private DefaultOAuth2UserService defaultOAuth2UserService;
+
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @BeforeEach
+    void setUp() {
+        // CustomOAuth2UserService 생성 및 defaultOAuth2UserService 주입
+        customOAuth2UserService = new CustomOAuth2UserService(
+            memberRepository,
+            nicknameGenerator
+        );
+
+        // ReflectionTestUtils를 사용하여 부모 클래스의 모킹된 서비스를 주입
+        ReflectionTestUtils.setField(customOAuth2UserService, "defaultOAuth2UserService", defaultOAuth2UserService);
+    }
+
+    @Test
+    @DisplayName("기존 회원 로드 성공")
+    void loadExistingUser() {
+        // given
+        String email = "existing@kakao.com";
+        Member existingMember = Member.builder()
+            .email(email)
+            .nickname("기존회원")
+            .accessToken("existing-token")
+            .provider(OAuth2Provider.KAKAO)
+            .totalQuestionCount(0L)
+            .correctAnswerCount(0L)
+            .build();
+
+        // 테스트 데이터 설정
+        Map<String, Object> kakaoAccount = new HashMap<>();
+        kakaoAccount.put("email", email);
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("id", 12345678L);
+        attributes.put("kakao_account", kakaoAccount);
+
+        OAuth2User oAuth2User = new DefaultOAuth2User(
+            Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+            attributes,
+            "id"
+        );
+
+        ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("kakao")
+            .clientId("test-client-id")
+            .clientSecret("test-client-secret")
+            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost:8080/login/oauth2/code/kakao")
+            .scope("account_email")
+            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
+            .tokenUri("https://kauth.kakao.com/oauth/token")
+            .userInfoUri("https://kapi.kakao.com/v2/user/me")
+            .userNameAttributeName("id")
+            .clientName("Kakao")
+            .build();
+
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            "test-token-value",
+            Instant.now(),
+            Instant.now().plus(Duration.ofHours(1))
+        );
+
+        OAuth2UserRequest userRequest = new OAuth2UserRequest(
+            clientRegistration,
+            accessToken
+        );
+
+        // Mocking - DefaultOAuth2UserService가 항상 우리가 설정한 OAuth2User를 반환하도록 설정
+        when(defaultOAuth2UserService.loadUser(any(OAuth2UserRequest.class))).thenReturn(oAuth2User);
+
+        // Mocking - 기존 회원이 존재하는 경우
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(existingMember));
+
+        // when
+        OAuth2User result = customOAuth2UserService.loadUser(userRequest);
+
+        // then
+        assertThat(result).isInstanceOf(MemberPrincipal.class);
+    }
+
+    @Test
+    @DisplayName("신규 회원 등록 성공")
+    void registerNewUser() {
+        // given
+        String email = "new@kakao.com";
+        String generatedNickname = "신규닉네임123";
+        String tokenValue = "new-token-value";
+
+        Member newMember = Member.builder()
+            .email(email)
+            .nickname(generatedNickname)
+            .accessToken(tokenValue)
+            .provider(OAuth2Provider.KAKAO)
+            .totalQuestionCount(0L)
+            .correctAnswerCount(0L)
+            .build();
+
+        // 테스트 데이터 설정
+        Map<String, Object> kakaoAccount = new HashMap<>();
+        kakaoAccount.put("email", email);
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("id", 87654321L);
+        attributes.put("kakao_account", kakaoAccount);
+
+        OAuth2User oAuth2User = new DefaultOAuth2User(
+            Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+            attributes,
+            "id"
+        );
+
+        ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("kakao")
+            .clientId("test-client-id")
+            .clientSecret("test-client-secret")
+            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost:8080/login/oauth2/code/kakao")
+            .scope("account_email")
+            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
+            .tokenUri("https://kauth.kakao.com/oauth/token")
+            .userInfoUri("https://kapi.kakao.com/v2/user/me")
+            .userNameAttributeName("id")
+            .clientName("Kakao")
+            .build();
+
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            tokenValue,
+            Instant.now(),
+            Instant.now().plus(Duration.ofHours(1))
+        );
+
+        OAuth2UserRequest userRequest = new OAuth2UserRequest(
+            clientRegistration,
+            accessToken
+        );
+
+        // Mocking
+        when(defaultOAuth2UserService.loadUser(any(OAuth2UserRequest.class))).thenReturn(oAuth2User);
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(nicknameGenerator.generateUniqueNickname()).thenReturn(generatedNickname);
+        when(memberRepository.save(any(Member.class))).thenReturn(newMember);
+
+        // when
+        OAuth2User result = customOAuth2UserService.loadUser(userRequest);
+
+        // then
+        assertThat(result).isInstanceOf(MemberPrincipal.class);
+        MemberPrincipal principal = (MemberPrincipal) result;
+        assertThat(principal.email()).isEqualTo(email);
+    }
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/common/config/SecurityConfigTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/common/config/SecurityConfigTest.java
@@ -3,20 +3,11 @@ package com.blooming.inpeak.common.config;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.blooming.inpeak.support.IntegrationTestSupport;
+import com.blooming.inpeak.support.ApiTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-class SecurityConfigTest extends IntegrationTestSupport {
-
-    @Autowired
-    private MockMvc mockMvc;
+class SecurityConfigTest extends ApiTestSupport {
 
     @DisplayName("개발 환경에서 모든 엔드포인트 접근 가능 테스트")
     @Test

--- a/inpeak/src/test/java/com/blooming/inpeak/common/config/SecurityConfigTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/common/config/SecurityConfigTest.java
@@ -3,7 +3,7 @@ package com.blooming.inpeak.common.config;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.blooming.inpeak.IntegrationTestSupport;
+import com.blooming.inpeak.support.IntegrationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/inpeak/src/test/java/com/blooming/inpeak/common/utils/JwtTokenProviderTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/common/utils/JwtTokenProviderTest.java
@@ -1,0 +1,138 @@
+package com.blooming.inpeak.common.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.domain.OAuth2Provider;
+import com.blooming.inpeak.support.IntegrationTestSupport;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("JwtTokenProvider 테스트")
+class JwtTokenProviderTest extends IntegrationTestSupport {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @DisplayName("토큰 생성 및 검증 테스트")
+    @Nested
+    class TokenGenerationAndValidation {
+
+        @DisplayName("토큰에서 사용자 ID 추출 성공")
+        @Test
+        void getUserIdFromToken_shouldReturnCorrectId() {
+            // given
+            Long memberId = 1L;
+            Member testMember = createTestMember(memberId);
+            String token = jwtTokenProvider.makeToken(testMember, Duration.ofMinutes(30));
+
+            // when
+            String extractedId = jwtTokenProvider.getUserIdFromToken(token);
+
+            // then
+            assertThat(extractedId).isEqualTo(memberId.toString());
+        }
+
+        @DisplayName("유효한 토큰 검증 성공")
+        @Test
+        void validateToken_withValidToken_shouldReturnTrue() {
+            // given
+            Member testMember = createTestMember(1L);
+            String token = jwtTokenProvider.makeToken(testMember, Duration.ofMinutes(30));
+
+            // when
+            boolean isValid = jwtTokenProvider.validateToken(token);
+
+            // then
+            assertThat(isValid).isTrue();
+        }
+
+        @DisplayName("만료된 토큰 검증 실패")
+        @Test
+        void validateToken_withExpiredToken_shouldReturnFalse() {
+            // given
+            Member testMember = createTestMember(1L);
+            String token = jwtTokenProvider.makeToken(testMember, Duration.ofMillis(1));
+
+            // 토큰 만료 대기
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            // when
+            boolean isValid = jwtTokenProvider.validateToken(token);
+
+            // then
+            assertThat(isValid).isFalse();
+        }
+
+        @DisplayName("잘못된 서명의 토큰 검증 실패")
+        @Test
+        void validateToken_withInvalidSignature_shouldReturnFalse() {
+            // given
+            Member testMember = createTestMember(1L);
+            String token = jwtTokenProvider.makeToken(testMember, Duration.ofMinutes(30));
+            String tampered = token.substring(0, token.lastIndexOf('.') + 1) + "tampered";
+
+            // when
+            boolean isValid = jwtTokenProvider.validateToken(tampered);
+
+            // then
+            assertThat(isValid).isFalse();
+        }
+    }
+
+    @DisplayName("예외 케이스 테스트")
+    @Nested
+    class ExceptionCases {
+
+        @DisplayName("만료된 토큰에서 ID 추출 시 예외 발생")
+        @Test
+        void getUserIdFromToken_withExpiredToken_shouldThrowException() {
+            // given
+            Member testMember = createTestMember(1L);
+            String expiredToken = jwtTokenProvider.makeToken(testMember, Duration.ofMillis(1));
+
+            // 토큰 만료 대기
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            // when & then
+            assertThatThrownBy(
+                () -> jwtTokenProvider.getUserIdFromToken(expiredToken))
+                .isInstanceOf(ExpiredJwtException.class);
+        }
+
+        @DisplayName("변조된 토큰에서 ID 추출 시 예외 발생")
+        @Test
+        void getUserIdFromToken_withTamperedToken_shouldThrowException() {
+            // given
+            Member testMember = createTestMember(1L);
+            String token = jwtTokenProvider.makeToken(testMember, Duration.ofMinutes(30));
+            String tampered = token.substring(0, token.lastIndexOf('.') + 1) + "tampered";
+
+            // when & then
+            assertThatThrownBy(
+                () -> jwtTokenProvider.getUserIdFromToken(tampered))
+                .isInstanceOf(SignatureException.class);
+        }
+    }
+
+    /**
+     * 테스트용 Member 객체 생성 헬퍼 메서드
+     */
+    private Member createTestMember(Long id) {
+        return new Member(id, "test@example.com", "테스트유저", "kakao-token", OAuth2Provider.KAKAO);
+    }
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/common/utils/NicknameGeneratorTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/common/utils/NicknameGeneratorTest.java
@@ -1,0 +1,31 @@
+package com.blooming.inpeak.common.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blooming.inpeak.member.repository.MemberRepository;
+import com.blooming.inpeak.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("닉네임 생성기 테스트")
+class NicknameGeneratorTest extends IntegrationTestSupport {
+
+    @Autowired
+    private NicknameGenerator nicknameGenerator;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("고유 닉네임 생성 성공")
+    @Test
+    void generateUniqueNickname() {
+        // when
+        String nickname = nicknameGenerator.generateUniqueNickname();
+
+        // then
+        assertThat(nickname).isNotNull();
+        assertThat(nickname).matches("^.+ .+ .+ \\d{4}$"); // 단어들과 숫자 4자리 패턴
+        assertThat(memberRepository.existsByNickname(nickname)).isFalse();
+    }
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/interview/repository/InterviewRepositoryTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/interview/repository/InterviewRepositoryTest.java
@@ -2,8 +2,8 @@ package com.blooming.inpeak.interview.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.blooming.inpeak.IntegrationTestSupport;
 import com.blooming.inpeak.interview.domain.Interview;
+import com.blooming.inpeak.support.IntegrationTestSupport;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/inpeak/src/test/java/com/blooming/inpeak/interview/service/InterviewServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/interview/service/InterviewServiceTest.java
@@ -2,11 +2,11 @@ package com.blooming.inpeak.interview.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.blooming.inpeak.IntegrationTestSupport;
 import com.blooming.inpeak.interview.domain.Interview;
 import com.blooming.inpeak.interview.dto.response.RemainingInterviewsResponse;
 import com.blooming.inpeak.interview.dto.response.TotalInterviewsResponse;
 import com.blooming.inpeak.interview.repository.InterviewRepository;
+import com.blooming.inpeak.support.IntegrationTestSupport;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/inpeak/src/test/java/com/blooming/inpeak/member/repository/MemberRepositoryTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.blooming.inpeak.member.repository;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.domain.OAuth2Provider;
+import com.blooming.inpeak.support.IntegrationTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("MemberRepository 테스트")
+class MemberRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAll();
+    }
+
+    // repository < (service test, 더 상위 개념)
+
+    @DisplayName("이메일로 회원 조회")
+    @Test
+    @Transactional
+    void findByEmail() {
+        // given
+        String email = "test@example.com";
+        Member member = Member.builder()
+            .email(email)
+            .nickname("테스트유저")
+            .accessToken("access-token")
+            .provider(OAuth2Provider.KAKAO)
+            .totalQuestionCount(0L)
+            .correctAnswerCount(0L)
+            .build();
+        memberRepository.save(member);
+
+        // when
+        Member found = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalStateException("해당 이메일의 회원이 존재하지 않습니다."));
+
+        // then
+        assertThat(found.getEmail()).isEqualTo("test@example.com");
+    }
+
+    @DisplayName("닉네임으로 회원 조회")
+    @Test
+    @Transactional
+    void existsByNickname() {
+        //given
+        String nickname = "유니크 닉네임";
+        Member member = Member.builder()
+            .email("test@example.com")
+            .nickname(nickname)
+            .accessToken("access-token")
+            .provider(OAuth2Provider.KAKAO)
+            .totalQuestionCount(0L)
+            .correctAnswerCount(0L)
+            .build();
+        memberRepository.save(member);
+
+        // when & then
+        assertThat(memberRepository.existsByNickname(nickname)).isTrue();
+        assertThat(memberRepository.existsByNickname("존재하지않는닉네임")).isFalse();
+    }
+
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/support/ApiTestSupport.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/support/ApiTestSupport.java
@@ -1,0 +1,17 @@
+package com.blooming.inpeak.support;
+
+import com.blooming.inpeak.HealthcheckController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {
+    HealthcheckController.class
+})
+@WithMockUser
+public abstract class ApiTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/support/IntegrationTestSupport.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/support/IntegrationTestSupport.java
@@ -1,5 +1,6 @@
-package com.blooming.inpeak;
+package com.blooming.inpeak.support;
 
+import com.blooming.inpeak.TestRedisConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #18 , #19 

## 📝 작업 내용
- OAuth2 인증 처리 로직 구현
  - CustomOAuth2UserService로 사용자 정보 처리
  - OAuth2 제공자별(카카오) 데이터 변환 로직
  - RefreshToken 저장 및 갱신 메커니즘

- 인증 관련 도메인 모델 구현
  - Member 엔티티에 OAuth2 관련 필드 추가
  - OAuth2Provider 열거형으로 지원 제공자 정의
  - RefreshToken 엔티티 및 저장소 구현

- 인증 성공 처리 로직 구현 
  - JWT 토큰 생성 및 반환
  - 리다이렉션 URL에 토큰 포함

- 보안 설정 구성
  - SecurityConfig에 OAuth2 로그인 설정
  - 세션리스(Stateless) 인증 흐름 구성

- 유틸리티 클래스 구현
  - 닉네임 자동 생성기
  - JWT 토큰 관리 유틸리티