### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
@@ -9,7 +9,7 @@ import com.blooming.inpeak.answer.dto.response.AnswerPresignedUrlResponse;
 import com.blooming.inpeak.answer.dto.response.InterviewWithAnswersResponse;
 import com.blooming.inpeak.answer.service.AnswerPresignedUrlService;
 import com.blooming.inpeak.answer.service.AnswerService;
-import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.dto.MemberPrincipal;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,46 +32,46 @@ public class AnswerController {
 
     @PostMapping("/skip")
     public ResponseEntity<Void> skipAnswer(
-        @AuthenticationPrincipal Member member,
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
         @RequestBody AnswerSkipRequest request
     ) {
-        answerService.skipAnswer(member.getId(), request.questionId(), request.interviewId());
+        answerService.skipAnswer(memberPrincipal.id(), request.questionId(), request.interviewId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping("/correct")
     public ResponseEntity<AnswerListResponse> getCorrectAnswerList(
-        @AuthenticationPrincipal Member member,
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
         CorrectAnswerFilterRequest request
     ) {
-        AnswerFilterCommand command = request.toCommand(member, 5);
+        AnswerFilterCommand command = request.toCommand(memberPrincipal, 5);
         return ResponseEntity.ok(answerService.getAnswerList(command));
     }
 
     @GetMapping("/incorrect")
     public ResponseEntity<AnswerListResponse> getIncorrectAnswerList(
-        @AuthenticationPrincipal Member member,
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
         IncorrectAnswerFilterRequest request
     ) {
-        AnswerFilterCommand command = request.toCommand(member, 10);
+        AnswerFilterCommand command = request.toCommand(memberPrincipal, 10);
         return ResponseEntity.ok(answerService.getAnswerList(command));
     }
 
     @GetMapping("/date")
     public ResponseEntity<InterviewWithAnswersResponse> getAnswersByDate(
-        @AuthenticationPrincipal Member member,
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
         @RequestParam LocalDate date
     ) {
-        return ResponseEntity.ok(answerService.getAnswersByDate(member.getId(), date));
+        return ResponseEntity.ok(answerService.getAnswersByDate(memberPrincipal.id(), date));
     }
 
     @GetMapping("/presigned-url")
     public ResponseEntity<AnswerPresignedUrlResponse> getPresignedUrl(
-        @AuthenticationPrincipal Member member,
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
         @RequestParam LocalDate startDate,
         @RequestParam String fileName
     ) {
         return ResponseEntity.ok(
-            answerPresignedUrlService.getPreSignedUrl(member.getId(), startDate, fileName));
+            answerPresignedUrlService.getPreSignedUrl(memberPrincipal.id(), startDate, fileName));
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/CorrectAnswerFilterRequest.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/CorrectAnswerFilterRequest.java
@@ -2,8 +2,9 @@ package com.blooming.inpeak.answer.dto.request;
 
 import com.blooming.inpeak.answer.domain.AnswerStatus;
 import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
-import com.blooming.inpeak.member.domain.Member;
-import jakarta.validation.constraints.*;
+import com.blooming.inpeak.member.dto.MemberPrincipal;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 public record CorrectAnswerFilterRequest(
     @NotNull
@@ -14,9 +15,9 @@ public record CorrectAnswerFilterRequest(
     @NotNull
     int page
 ) {
-    public AnswerFilterCommand toCommand(Member member, int size) {
+    public AnswerFilterCommand toCommand(MemberPrincipal member, int size) {
         return AnswerFilterCommand.builder()
-            .memberId(member.getId())
+            .memberId(member.id())
             .isUnderstood(isUnderstood)
             .status(AnswerStatus.CORRECT)
             .sortType(sortType)

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/IncorrectAnswerFilterRequest.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/request/IncorrectAnswerFilterRequest.java
@@ -2,7 +2,7 @@ package com.blooming.inpeak.answer.dto.request;
 
 import com.blooming.inpeak.answer.domain.AnswerStatus;
 import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
-import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.dto.MemberPrincipal;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
@@ -15,9 +15,9 @@ public record IncorrectAnswerFilterRequest(
     @NotNull
     int page
 ) {
-    public AnswerFilterCommand toCommand(Member member, int size) {
+    public AnswerFilterCommand toCommand(MemberPrincipal member, int size) {
         return AnswerFilterCommand.builder()
-            .memberId(member.getId())
+            .memberId(member.id())
             .status(status)
             .sortType(sortType)
             .page(page)

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/controller/AuthController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.blooming.inpeak.auth.controller;
+
+import com.blooming.inpeak.auth.service.AuthService;
+import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.dto.MemberPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/test")
+    public String test(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        System.out.println("member = " + memberPrincipal.email());
+        return memberPrincipal.toString();
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/controller/AuthController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.blooming.inpeak.auth.service.AuthService;
 import com.blooming.inpeak.member.domain.Member;
 import com.blooming.inpeak.member.dto.MemberPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,5 +23,14 @@ public class AuthController {
     public String test(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
         System.out.println("member = " + memberPrincipal.email());
         return memberPrincipal.toString();
+    }
+
+    // TODO: Authentication 객체를 사용하는 것이 좋을까요? @AuthenticationPrincipal 애너테이션을 사용하는 것이 좋을까요?
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(Authentication authentication) {
+        MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
+
+        authService.logout(principal.id());
+        return ResponseEntity.ok().build();
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilter.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilter.java
@@ -76,7 +76,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().write("{\"message\":\"" + message + "\"}");
+//        response.getWriter().write("{\"message\":\"" + message + "\"}");
 
         if (log.isErrorEnabled()) {
             log.error("인증 필터에서 요청이 중단됨: {}", message);

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilter.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilter.java
@@ -76,7 +76,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
-//        response.getWriter().write("{\"message\":\"" + message + "\"}");
+        response.getWriter().write("{\"message\":\"" + message + "\"}");
 
         if (log.isErrorEnabled()) {
             log.error("인증 필터에서 요청이 중단됨: {}", message);

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/repository/RefreshTokenRepository.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/repository/RefreshTokenRepository.java
@@ -9,4 +9,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByMemberId(Long memberId);
 
     Optional<RefreshToken> findByRefreshToken(String tokenValue);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/service/AuthService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/service/AuthService.java
@@ -3,10 +3,17 @@ package com.blooming.inpeak.auth.service;
 import com.blooming.inpeak.auth.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthService {
 
     private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public void logout(Long memberId) {
+        refreshTokenRepository.deleteByMemberId(memberId);
+    }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/service/AuthService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/service/AuthService.java
@@ -1,0 +1,12 @@
+package com.blooming.inpeak.auth.service;
+
+import com.blooming.inpeak.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/interview/controller/InterviewController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/interview/controller/InterviewController.java
@@ -4,7 +4,7 @@ import com.blooming.inpeak.interview.dto.response.CalendarResponse;
 import com.blooming.inpeak.interview.dto.response.InterviewStartResponse;
 import com.blooming.inpeak.interview.service.InterviewService;
 import com.blooming.inpeak.interview.service.InterviewStartService;
-import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.dto.MemberPrincipal;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,19 +27,21 @@ public class InterviewController {
 
     @GetMapping("/calendar")
     public ResponseEntity<List<CalendarResponse>> getCalendar(
-        @AuthenticationPrincipal Member member,
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
         @RequestParam int month,
         @RequestParam int year
     ) {
-        return ResponseEntity.ok(interviewService.getCalendar(member.getId(), month, year));
+        return ResponseEntity.ok(interviewService.getCalendar(memberPrincipal.id(), month, year));
     }
 
     @PostMapping("/start")
     public ResponseEntity<InterviewStartResponse> startInterview(
-        @AuthenticationPrincipal Member member,
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
         @RequestParam LocalDate startDate
     ) {
-        InterviewStartResponse response = interviewStartService.startInterview(member.getId(), startDate);
+        InterviewStartResponse response =
+            interviewStartService.startInterview(memberPrincipal.id(), startDate);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/controller/MemberController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/controller/MemberController.java
@@ -1,0 +1,10 @@
+package com.blooming.inpeak.member.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+public class MemberController {
+
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
@@ -10,11 +10,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.Collection;
+import java.util.Collections;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
@@ -83,16 +85,16 @@ public class Member extends BaseEntity implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
     }
 
     @Override
     public String getPassword() {
-        return null; // OAuth2 로그인이므로 패스워드 필요 없음
+        return "";
     }
 
     @Override
     public String getUsername() {
-        return email; // 사용자 식별자로 이메일 사용
+        return email;
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #49, close #16, close #20 

<br>

## 📝 작업 내용
- `refresh token` 무효화 처리
- `AuthenticationPrincipal` 애너테이션 사용 방식 수정 (`Member` -> `MemberPrincipal`)

<br>

## 💬 리뷰 요구사항
- `access token` 무효화는 어떻게 해야 될 지 고민이 됩니다. 
- [AuthController](https://github.com/blooming-inpeak/inpeak-backend/compare/feat/%2349-logout-implementation?expand=1#diff-c839bc2c7950561441d25b463f12c6acd57c0064325257eb89ba3816454a2bc2) 파일처럼 `@AuthenticationPrincipal` 애너테이션을 사용하려면 `MemberPrincipal`를 사용해야 되고, 아니라면 `Authentication` 객체를 통해 `Principal 객체`를 꺼내올 수 있습니다.
