### PR TITLE
Feat/#55 member interests

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerPresignedUrlService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerPresignedUrlService.java
@@ -38,7 +38,6 @@ public class AnswerPresignedUrlService {
      * @return Presigned URL
      */
     public AnswerPresignedUrlResponse getPreSignedUrl(Long memberId, LocalDate startDate, String fileName) {
-
         // 파일명에서 확장자 추출 및 Object Key 생성
         String extension = extractExtension(fileName);
         String key = generateObjectKey(memberId, startDate, extension);

--- a/inpeak/src/main/java/com/blooming/inpeak/interview/service/InterviewStartService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/interview/service/InterviewStartService.java
@@ -31,7 +31,7 @@ public class InterviewStartService {
         Long interviewId = interviewService.createInterview(memberId, startDate);
 
         // 사용자의 관심사를 가져와 질문을 필터링
-        List<InterestType> interestTypes = memberInterestService.getUserInterestTypes(memberId);
+        List<InterestType> interestTypes = memberInterestService.getMemberInterestTypes(memberId);
         List<QuestionResponse> questionResponse = questionService.getFilteredQuestions(memberId, interestTypes);
 
         return InterviewStartResponse.of(interviewId, questionResponse);

--- a/inpeak/src/main/java/com/blooming/inpeak/member/controller/MemberInterestController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/controller/MemberInterestController.java
@@ -1,0 +1,26 @@
+package com.blooming.inpeak.member.controller;
+
+import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.dto.response.MemberInterestResponse;
+import com.blooming.inpeak.member.service.MemberInterestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/interest")
+@RequiredArgsConstructor
+public class MemberInterestController {
+
+    private final MemberInterestService memberInterestService;
+
+    @GetMapping("/list")
+    public ResponseEntity<MemberInterestResponse> getMemberInterest(
+        @AuthenticationPrincipal Member member
+    ) {
+        return ResponseEntity.ok(memberInterestService.getMemberInterestStrings(member.getId()));
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/member/controller/MemberInterestController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/controller/MemberInterestController.java
@@ -1,6 +1,6 @@
 package com.blooming.inpeak.member.controller;
 
-import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.dto.MemberPrincipal;
 import com.blooming.inpeak.member.dto.response.MemberInterestResponse;
 import com.blooming.inpeak.member.service.MemberInterestService;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +19,9 @@ public class MemberInterestController {
 
     @GetMapping("/list")
     public ResponseEntity<MemberInterestResponse> getMemberInterest(
-        @AuthenticationPrincipal Member member
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal
     ) {
-        return ResponseEntity.ok(memberInterestService.getMemberInterestStrings(member.getId()));
+        return ResponseEntity.ok(
+            memberInterestService.getMemberInterestStrings(memberPrincipal.id()));
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/InterestType.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/InterestType.java
@@ -3,5 +3,10 @@ package com.blooming.inpeak.member.domain;
 public enum InterestType {
     REACT,
     SPRING,
-    DATABASE,
+    DATABASE;
+
+    public String toFormattedString() {
+        String lower = name().toLowerCase();
+        return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+    }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/dto/response/MemberInterestResponse.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/dto/response/MemberInterestResponse.java
@@ -1,0 +1,10 @@
+package com.blooming.inpeak.member.dto.response;
+
+import java.util.List;
+
+public record MemberInterestResponse(List<String> interests) {
+
+    public static MemberInterestResponse of(List<String> interests) {
+        return new MemberInterestResponse(interests);
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/member/service/MemberInterestService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/service/MemberInterestService.java
@@ -22,10 +22,15 @@ public class MemberInterestService {
      * @return 회원의 관심사 리스트
      */
     public List<InterestType> getMemberInterestTypes(Long memberId) {
-
         return memberInterestRepository.findInterestsByMemberId(memberId);
     }
 
+    /**
+     * 회원의 관심사를 포맷팅된 문자열로 가져오는 메서드
+     *
+     * @param memberId 사용자 ID
+     * @return 회원의 관심사 문자열 리스트
+     */
     public MemberInterestResponse getMemberInterestStrings(Long memberId) {
         List<InterestType> interests = getMemberInterestTypes(memberId);
 

--- a/inpeak/src/main/java/com/blooming/inpeak/member/service/MemberInterestService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/service/MemberInterestService.java
@@ -1,6 +1,7 @@
 package com.blooming.inpeak.member.service;
 
 import com.blooming.inpeak.member.domain.InterestType;
+import com.blooming.inpeak.member.dto.response.MemberInterestResponse;
 import com.blooming.inpeak.member.repository.MemberInterestRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +21,18 @@ public class MemberInterestService {
      * @param memberId 사용자 ID
      * @return 회원의 관심사 리스트
      */
-    public List<InterestType> getUserInterestTypes(Long memberId) {
+    public List<InterestType> getMemberInterestTypes(Long memberId) {
 
         return memberInterestRepository.findInterestsByMemberId(memberId);
+    }
+
+    public MemberInterestResponse getMemberInterestStrings(Long memberId) {
+        List<InterestType> interests = getMemberInterestTypes(memberId);
+
+        List<String> interestStrings = interests.stream()
+            .map(InterestType::toFormattedString)
+            .toList();
+
+        return MemberInterestResponse.of(interestStrings);
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/question/service/QuestionService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/question/service/QuestionService.java
@@ -29,7 +29,6 @@ public class QuestionService {
      * @return 질문 리스트
      */
     public List<QuestionResponse> getFilteredQuestions(Long memberId, List<InterestType> interestTypes) {
-
         // InterestType -> QuestionType 변환 후 직군별 기본 질문 타입 추가
         List<QuestionType> types = convertToQuestionType(interestTypes);
         List<String> typeStrings = addDefaultQuestionType(types);

--- a/inpeak/src/test/java/com/blooming/inpeak/member/service/MemberInterestServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/member/service/MemberInterestServiceTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 class MemberInterestServiceTest extends IntegrationTestSupport {
 
@@ -23,17 +24,35 @@ class MemberInterestServiceTest extends IntegrationTestSupport {
     private static final Long MEMBER_ID = 1L;
 
     @Test
+    @Transactional
     @DisplayName("회원 ID로 관심사를 조회하면, 해당 회원의 모든 InterestType을 반환해야 한다.")
-    void getUserInterestTypes_ShouldReturnAllInterestsForGivenMemberId() {
+    void getMemberInterestTypes_ShouldReturnAllInterestsForGivenMemberId() {
         // given
         memberInterestRepository.save(MemberInterest.of(MEMBER_ID, InterestType.REACT));
         memberInterestRepository.save(MemberInterest.of(MEMBER_ID, InterestType.SPRING));
 
         // when
-        List<InterestType> interests = memberInterestService.getUserInterestTypes(MEMBER_ID);
+        List<InterestType> interests = memberInterestService.getMemberInterestTypes(MEMBER_ID);
 
         // then
         assertThat(interests).hasSize(2);
         assertThat(interests).containsExactlyInAnyOrder(InterestType.REACT, InterestType.SPRING);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("회원 ID로 관심사를 조회하면, 해당 회원의 모든 InterestType을 포맷팅된 문자열로 반환해야 한다.")
+    void getMemberInterestStrings_ShouldReturnFormattingStrings() {
+        // given
+        memberInterestRepository.save(MemberInterest.of(MEMBER_ID, InterestType.REACT));
+        memberInterestRepository.save(MemberInterest.of(MEMBER_ID, InterestType.SPRING));
+
+        // when
+        List<String> interestStrings =
+            memberInterestService.getMemberInterestStrings(MEMBER_ID).interests();
+
+        // then
+        assertThat(interestStrings).hasSize(2);
+        assertThat(interestStrings).containsExactlyInAnyOrder("React", "Spring");
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈

- close #55 

## 📝 작업 내용

- 첫 번째 글자는 대문자, 이후 글자는 소문자로 포맷팅된 문자열 형식의 회원 관심사 리스트를 반환합니다.
- javadoc을 추가하였습니다.
- 컨벤션에 맞춰 코드 스타일을 변경했습니다.
- `@AuthenticationPrincipal` 객체 타입을 변경했습니다.

## 🎸 기타 (선택)
> 고려해야 하는 내용을 작성해 주세요.

## 💬 리뷰 요구사항(선택)

- [MemberInterestController](https://github.com/blooming-inpeak/inpeak-backend/pull/57/files#diff-2e76fbed34cfe42b3b6c9572d798a30a6146069c092dd60df1b939ca35265f91).getMemberInterest() 메서드를 `MemberController`로 옮길까요?