### PR TITLE
feat: Security filter를 통한 회원가입 검증 로직 개선 (#56)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/auth/service/CustomOAuth2UserService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/service/CustomOAuth2UserService.java
@@ -3,6 +3,7 @@ package com.blooming.inpeak.auth.service;
 import com.blooming.inpeak.common.utils.NicknameGenerator;
 import com.blooming.inpeak.member.domain.Member;
 import com.blooming.inpeak.member.domain.OAuth2Provider;
+import com.blooming.inpeak.member.domain.RegistrationStatus;
 import com.blooming.inpeak.member.dto.MemberPrincipal;
 import com.blooming.inpeak.member.dto.OAuth2Command;
 import com.blooming.inpeak.member.repository.MemberRepository;
@@ -42,7 +43,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String userNameAttributeName = userRequest.getClientRegistration()
             .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
 
-        OAuth2Command oAuth2Command = OAuth2Command.of(provider, userNameAttributeName, oAuth2User.getAttributes());
+        OAuth2Command oAuth2Command = OAuth2Command.of(
+            provider, userNameAttributeName, oAuth2User.getAttributes()
+        );
 
         String email = oAuth2Command.getEmail();
         String accessToken = userRequest.getAccessToken().getTokenValue();
@@ -64,6 +67,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             .provider(provider)
             .totalQuestionCount(0L)
             .correctAnswerCount(0L)
+            .registrationStatus(RegistrationStatus.INITIATED)
             .build();
 
         return memberRepository.save(member);

--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
@@ -48,10 +48,15 @@ public class Member extends BaseEntity implements UserDetails {
     @Column(nullable = false)
     private OAuth2Provider provider;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RegistrationStatus registrationStatus;
+
     @Builder
     private Member(
         String email, String nickname, String accessToken,
-        Long totalQuestionCount, Long correctAnswerCount, OAuth2Provider provider
+        Long totalQuestionCount, Long correctAnswerCount, OAuth2Provider provider,
+        RegistrationStatus registrationStatus
     ) {
         this.email = email;
         this.nickname = nickname;
@@ -59,27 +64,36 @@ public class Member extends BaseEntity implements UserDetails {
         this.totalQuestionCount = totalQuestionCount;
         this.correctAnswerCount = correctAnswerCount;
         this.provider = provider;
+        this.registrationStatus =
+            registrationStatus != null ? registrationStatus : RegistrationStatus.INITIATED;
     }
 
     // 테스트 파일에서 사용할 생성자
     @Builder(access = AccessLevel.PRIVATE)
     public Member(
         Long id, String email, String nickname, String accessToken,
-        OAuth2Provider provider
+        OAuth2Provider provider, RegistrationStatus registrationStatus
     ) {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
         this.accessToken = accessToken;
         this.provider = provider;
+        this.registrationStatus =
+            registrationStatus != null ? registrationStatus : RegistrationStatus.INITIATED;
     }
 
-    public static Member of(String email, String nickname, String accessToken, OAuth2Provider provider) {
+    public static Member of(
+        String email, String nickname, String accessToken,
+        OAuth2Provider provider, RegistrationStatus registrationStatus
+    ) {
         return Member.builder()
             .email(email)
             .nickname(nickname)
             .accessToken(accessToken)
             .provider(provider)
+            .registrationStatus(
+                registrationStatus != null ? registrationStatus : RegistrationStatus.INITIATED)
             .build();
     }
 
@@ -96,5 +110,9 @@ public class Member extends BaseEntity implements UserDetails {
     @Override
     public String getUsername() {
         return email;
+    }
+
+    public boolean registrationCompleted() {
+        return registrationStatus == RegistrationStatus.COMPLETED;
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/RegistrationStatus.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/RegistrationStatus.java
@@ -1,0 +1,6 @@
+package com.blooming.inpeak.member.domain;
+
+public enum RegistrationStatus {
+    INITIATED,          // 소셜 로그인 인증 완료
+    COMPLETED;          // 회원가입 완료
+}

--- a/inpeak/src/test/java/com/blooming/inpeak/answer/repository/AnswerRepositoryCustomTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/answer/repository/AnswerRepositoryCustomTest.java
@@ -6,6 +6,7 @@ import com.blooming.inpeak.answer.domain.Answer;
 import com.blooming.inpeak.answer.domain.AnswerStatus;
 import com.blooming.inpeak.interview.domain.Interview;
 import com.blooming.inpeak.member.domain.OAuth2Provider;
+import com.blooming.inpeak.member.domain.RegistrationStatus;
 import com.blooming.inpeak.question.domain.Question;
 import com.blooming.inpeak.question.domain.QuestionType;
 import com.blooming.inpeak.common.config.queryDSL.QuerydslConfig;
@@ -51,7 +52,8 @@ class AnswerRepositoryCustomTest {
                 "test@test.com",
                 "test",
                 "test",
-                OAuth2Provider.KAKAO
+                OAuth2Provider.KAKAO,
+                RegistrationStatus.COMPLETED
             )
         );
 

--- a/inpeak/src/test/java/com/blooming/inpeak/common/utils/JwtTokenProviderTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/common/utils/JwtTokenProviderTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.blooming.inpeak.auth.utils.JwtTokenProvider;
 import com.blooming.inpeak.member.domain.Member;
 import com.blooming.inpeak.member.domain.OAuth2Provider;
+import com.blooming.inpeak.member.domain.RegistrationStatus;
 import com.blooming.inpeak.support.IntegrationTestSupport;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
@@ -134,6 +135,8 @@ class JwtTokenProviderTest extends IntegrationTestSupport {
      * 테스트용 Member 객체 생성 헬퍼 메서드
      */
     private Member createTestMember(Long id) {
-        return new Member(id, "test@example.com", "테스트유저", "kakao-token", OAuth2Provider.KAKAO);
+        return new Member(
+            id, "test@example.com", "테스트유저", "kakao-token",
+            OAuth2Provider.KAKAO, RegistrationStatus.COMPLETED);
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #56 

## 📝 작업 내용
- `TokenAuthenticationFilter`에 회원 가입 완료 여부 확인 로직 구현
- 회원가입이 미완료된 회원은 API 접근 제한
  - ex) `선호하는 기술 스택`을 선택하지 않았다면
           `488` 코드와 함께 `가입이 완료되지 않은 사용자입니다` 라는 message 반환

## 🎸 기타 (선택)

## 💬 리뷰 요구사항(선택)
