### PR TITLE
feat: 회원 등록 상태에 따른 API 접근 제어 개선 (#61)

### DIFF
--- a/inpeak/src/test/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilterTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilterTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 
 import com.blooming.inpeak.auth.utils.JwtTokenProvider;
 import com.blooming.inpeak.member.domain.Member;
@@ -56,6 +57,8 @@ class TokenAuthenticationFilterTest {
         String userId = "1";
         Member mockMember = mock(Member.class);
 
+        given(request.getServletPath()).willReturn("/healthcheck");
+
         given(request.getHeader("Authorization")).willReturn("Bearer " + token);
         given(jwtTokenProvider.validateToken(token)).willReturn(true);
         given(jwtTokenProvider.getUserIdFromToken(token)).willReturn(userId);
@@ -65,7 +68,8 @@ class TokenAuthenticationFilterTest {
         // SecurityContext와 관련된 추가 모킹
         MemberPrincipal mockPrincipal = mock(MemberPrincipal.class);
         try (MockedStatic<MemberPrincipal> mockedStatic = mockStatic(MemberPrincipal.class)) {
-            mockedStatic.when(() -> MemberPrincipal.create(any(Member.class), any())).thenReturn(mockPrincipal);
+            mockedStatic.when(
+                () -> MemberPrincipal.create(any(Member.class), any())).thenReturn(mockPrincipal);
 
             // when
             tokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -95,5 +99,63 @@ class TokenAuthenticationFilterTest {
         printWriter.flush();
         String responseBody = stringWriter.toString();
         assert(responseBody.contains("헤더에 액세스 토큰이 없거나, Bearer 접두어가 빠져있습니다"));
+    }
+
+    @DisplayName("회원 등록이 완료되지 않은 사용자가 일반 API에 접근하면 488 응답을 반환한다")
+    @Test
+    void whenUserRegistrationNotCompleted_andAccessRegularAPI_thenReturns488() throws Exception {
+        // given
+        String token = "valid-token";
+        String userId = "1";
+        Member mockMember = mock(Member.class);
+
+        given(request.getServletPath()).willReturn("/api/member/profile");
+        given(request.getHeader("Authorization")).willReturn("Bearer " + token);
+        given(jwtTokenProvider.validateToken(token)).willReturn(true);
+        given(jwtTokenProvider.getUserIdFromToken(token)).willReturn(userId);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(mockMember));
+        given(mockMember.registrationCompleted()).willReturn(false);
+
+        // StringWriter와 PrintWriter를 사용하여 응답 캡처
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        given(response.getWriter()).willReturn(writer);
+
+        // when
+        tokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        then(response).should().setStatus(488);
+        then(filterChain).should(never()).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class));
+        writer.flush();
+        assert(stringWriter.toString()).contains("가입이 완료되지 않은 사용자입니다");
+    }
+
+    @DisplayName("회원 등록이 완료되지 않은 사용자도 등록 관련 API에는 접근할 수 있다")
+    @Test
+    void whenUserRegistrationNotCompleted_andAccessRegistrationAPI_thenProceedsToNextFilter() throws Exception {
+        // given
+        String token = "valid-token";
+        String userId = "1";
+        Member mockMember = mock(Member.class);
+
+        given(request.getServletPath()).willReturn("/interest");
+        given(request.getHeader("Authorization")).willReturn("Bearer " + token);
+        given(jwtTokenProvider.validateToken(token)).willReturn(true);
+        given(jwtTokenProvider.getUserIdFromToken(token)).willReturn(userId);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(mockMember));
+        given(mockMember.registrationCompleted()).willReturn(false);
+
+        // SecurityContext와 관련된 추가 모킹
+        MemberPrincipal mockPrincipal = mock(MemberPrincipal.class);
+        try (MockedStatic<MemberPrincipal> mockedStatic = mockStatic(MemberPrincipal.class)) {
+            mockedStatic.when(() -> MemberPrincipal.create(any(Member.class), any())).thenReturn(mockPrincipal);
+
+            // when
+            tokenAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+            // then
+            then(filterChain).should().doFilter(request, response);
+        }
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #61

## 📝 작업 내용
- TokenAuthenticationFilter에 회원 등록 완료 여부 접근 허용 로직 추가
    - `선호하는 기술 스택` 관련 api 접근 허용하도록 개선
- 미등록 상태 사용자는 `등록 관련 API`만 접근 가능
- 테스트 코드 추가 및 기존 테스트 수정

## 🎸 기타 (선택)

## 💬 리뷰 요구사항(선택)
