### PR TITLE
feat: 최근 질문 히스토리 구현 (#72)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/controller/AnswerController.java
@@ -1,5 +1,6 @@
 package com.blooming.inpeak.answer.controller;
 
+import com.blooming.inpeak.answer.domain.AnswerStatus;
 import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
 import com.blooming.inpeak.answer.dto.request.AnswerCreateRequest;
 import com.blooming.inpeak.answer.dto.request.AnswerSkipRequest;
@@ -8,6 +9,7 @@ import com.blooming.inpeak.answer.dto.request.IncorrectAnswerFilterRequest;
 import com.blooming.inpeak.answer.dto.response.AnswerListResponse;
 import com.blooming.inpeak.answer.dto.response.AnswerPresignedUrlResponse;
 import com.blooming.inpeak.answer.dto.response.InterviewWithAnswersResponse;
+import com.blooming.inpeak.answer.dto.response.RecentAnswerListResponse;
 import com.blooming.inpeak.answer.service.AnswerPresignedUrlService;
 import com.blooming.inpeak.answer.service.AnswerService;
 import com.blooming.inpeak.member.dto.MemberPrincipal;
@@ -65,6 +67,14 @@ public class AnswerController {
         @RequestParam LocalDate date
     ) {
         return ResponseEntity.ok(answerService.getAnswersByDate(memberPrincipal.id(), date));
+    }
+
+    @GetMapping("/recent")
+    public ResponseEntity<RecentAnswerListResponse> getRecentAnswers(
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+        @RequestParam(required = false, defaultValue = "ALL") AnswerStatus status
+    ) {
+        return ResponseEntity.ok(answerService.getRecentAnswers(memberPrincipal.id(), status));
     }
 
     @GetMapping("/presigned-url")

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/RecentAnswerListResponse.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/RecentAnswerListResponse.java
@@ -1,0 +1,14 @@
+package com.blooming.inpeak.answer.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record RecentAnswerListResponse(List<RecentAnswerResponse> recentAnswers) {
+
+    public static RecentAnswerListResponse from(List<RecentAnswerResponse> recentAnswers) {
+        return RecentAnswerListResponse.builder()
+            .recentAnswers(recentAnswers)
+            .build();
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/RecentAnswerResponse.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/dto/response/RecentAnswerResponse.java
@@ -1,0 +1,27 @@
+package com.blooming.inpeak.answer.dto.response;
+
+import com.blooming.inpeak.answer.domain.Answer;
+import com.blooming.inpeak.answer.domain.AnswerStatus;
+import lombok.Builder;
+
+@Builder
+public record RecentAnswerResponse(
+    Long interviewId,
+    Long questionId,
+    Long answerId,
+    String questionContent,
+    String answerContent,
+    AnswerStatus answerStatus
+) {
+
+    public static RecentAnswerResponse from(Answer answer) {
+        return RecentAnswerResponse.builder()
+            .interviewId(answer.getInterviewId())
+            .questionId(answer.getQuestionId())
+            .answerId(answer.getId())
+            .questionContent(answer.getQuestion().getContent())
+            .answerContent(answer.getUserAnswer())
+            .answerStatus(answer.getStatus())
+            .build();
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
@@ -7,6 +7,8 @@ import com.blooming.inpeak.answer.dto.command.AnswerFilterCommand;
 import com.blooming.inpeak.answer.dto.response.AnswerListResponse;
 import com.blooming.inpeak.answer.dto.response.AnswerResponse;
 import com.blooming.inpeak.answer.dto.response.InterviewWithAnswersResponse;
+import com.blooming.inpeak.answer.dto.response.RecentAnswerListResponse;
+import com.blooming.inpeak.answer.dto.response.RecentAnswerResponse;
 import com.blooming.inpeak.answer.repository.AnswerRepository;
 import com.blooming.inpeak.answer.repository.AnswerRepositoryCustom;
 import com.blooming.inpeak.answer.repository.UserAnswerStatsRepository;
@@ -19,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,6 +91,23 @@ public class AnswerService {
             .orElseThrow(() -> new IllegalStateException("해당 날짜에 진행된 인터뷰가 없습니다."));
 
         return InterviewWithAnswersResponse.from(interview, answers);
+    }
+
+    /**
+     * 답변 상태를 기준으로 필터링하여 최근 3개의 답변 리스트를 반환하는 메서드
+     *
+     * @param memberId 회원 ID
+     * @param status   필터링 할 답변 상태
+     * @return 최근 3개의 답변 리스트
+     */
+    public RecentAnswerListResponse getRecentAnswers(Long memberId, AnswerStatus status) {
+        List<Answer> answers = answerRepositoryCustom.findRecentAnswers(memberId, status);
+
+        List<RecentAnswerResponse> responseList = answers.stream()
+            .map(RecentAnswerResponse::from)
+            .toList();
+
+        return RecentAnswerListResponse.from(responseList);
     }
 
     /**


### PR DESCRIPTION
## ⚡️ 관련 이슈

- close #72 
## 📝 작업 내용

- 최근 질문 리스트를 반환합니다.
- 답변 상태 필터에 따라 최대 3개의 리스트를 반환합니다.

## 🎸 기타 (선택)
> 
## 💬 리뷰 요구사항(선택)

> 
