### PR TITLE
feat: 회원 관심사 등록 및 수정 API (#71)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilter.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     // 회원 등록 관련 경로 상수로 정의
     private final List<String> REGISTRATION_PATHS = List.of(
         "/interest",
-        "/interest/registration"
+        "/interest/list"
     );
 
     @Override

--- a/inpeak/src/main/java/com/blooming/inpeak/member/controller/MemberInterestController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/controller/MemberInterestController.java
@@ -1,12 +1,18 @@
 package com.blooming.inpeak.member.controller;
 
 import com.blooming.inpeak.member.dto.MemberPrincipal;
+import com.blooming.inpeak.member.dto.request.MemberInterestRequest;
 import com.blooming.inpeak.member.dto.response.MemberInterestResponse;
 import com.blooming.inpeak.member.service.MemberInterestService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +29,23 @@ public class MemberInterestController {
     ) {
         return ResponseEntity.ok(
             memberInterestService.getMemberInterestStrings(memberPrincipal.id()));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> registerInterests(
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+        @Valid @RequestBody MemberInterestRequest request
+    ) {
+        memberInterestService.registerInitialInterests(memberPrincipal.id(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> updateInterests(
+        @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+        @Valid @RequestBody MemberInterestRequest request
+    ) {
+        memberInterestService.updateInterests(memberPrincipal.id(), request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
@@ -115,4 +115,8 @@ public class Member extends BaseEntity implements UserDetails {
     public boolean registrationCompleted() {
         return registrationStatus == RegistrationStatus.COMPLETED;
     }
+
+    public void completeRegistration() {
+        this.registrationStatus = RegistrationStatus.COMPLETED;
+    }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/dto/request/MemberInterestRequest.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/dto/request/MemberInterestRequest.java
@@ -1,0 +1,13 @@
+package com.blooming.inpeak.member.dto.request;
+
+import com.blooming.inpeak.member.domain.InterestType;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record MemberInterestRequest(
+    @NotNull(message = "관심사를 입력해주세요.")
+    @NotEmpty(message = "최소 하나 이상의 관심 분야를 선택해야 합니다.")
+    List<InterestType> interestTypes
+) {
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/member/repository/MemberInterestRepository.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/repository/MemberInterestRepository.java
@@ -12,4 +12,6 @@ public interface MemberInterestRepository extends JpaRepository<MemberInterest, 
 
     @Query("SELECT mi.interestType FROM MemberInterest mi WHERE mi.memberId = :memberId")
     List<InterestType> findInterestsByMemberId(Long memberId);
+
+    void deleteByMemberId(Long id);
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/service/MemberInterestService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/service/MemberInterestService.java
@@ -1,9 +1,15 @@
 package com.blooming.inpeak.member.service;
 
 import com.blooming.inpeak.member.domain.InterestType;
+import com.blooming.inpeak.member.domain.Member;
+import com.blooming.inpeak.member.domain.MemberInterest;
+import com.blooming.inpeak.member.dto.request.MemberInterestRequest;
 import com.blooming.inpeak.member.dto.response.MemberInterestResponse;
 import com.blooming.inpeak.member.repository.MemberInterestRepository;
+import com.blooming.inpeak.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberInterestService {
 
     private final MemberInterestRepository memberInterestRepository;
+    private final MemberRepository memberRepository;
 
     /**
      * 회원의 관심사를 가져오는 메서드
@@ -39,5 +46,50 @@ public class MemberInterestService {
             .toList();
 
         return MemberInterestResponse.of(interestStrings);
+    }
+
+    @Transactional
+    public void registerInitialInterests(Long memberId, MemberInterestRequest request) {
+        Member member = getMemberById(memberId);
+
+        if (member.registrationCompleted()) {
+            throw new IllegalStateException("이미 회원 등록이 완료되었습니다: " + memberId);
+        }
+
+        // 관심사 업데이트
+        updateMemberInterests(memberId, request.interestTypes());
+
+        // 초기 등록시에만 회원 상태 업데이트
+        member.completeRegistration();
+        memberRepository.save(member);
+    }
+
+    @Transactional
+    public void updateInterests(Long memberId, MemberInterestRequest request) {
+        Member member = getMemberById(memberId);
+
+        if (!member.registrationCompleted()) {
+            throw new IllegalStateException("회원 등록이 완료되지 않았습니다: " + memberId);
+        }
+
+        updateMemberInterests(memberId, request.interestTypes());
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new EntityNotFoundException("해당 사용자가 존재하지 않습니다: " + memberId));
+    }
+
+    // TODO: 현재 기존 관심사 delete 후 insert 발생, (성능 고려 해야되나?)
+    private void updateMemberInterests(Long memberId, List<InterestType> interestTypes) {
+        // 기존 관심사 삭제
+        memberInterestRepository.deleteByMemberId(memberId);
+
+        // 새 관심사 저장
+        List<MemberInterest> interests = interestTypes.stream()
+            .map(interestType -> MemberInterest.of(memberId, interestType))
+            .collect(Collectors.toList());
+
+        memberInterestRepository.saveAll(interests);
     }
 }

--- a/inpeak/src/test/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilterTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilterTest.java
@@ -139,7 +139,7 @@ class TokenAuthenticationFilterTest {
         String userId = "1";
         Member mockMember = mock(Member.class);
 
-        given(request.getServletPath()).willReturn("/interest");
+        given(request.getServletPath()).willReturn("/interest/list");
         given(request.getHeader("Authorization")).willReturn("Bearer " + token);
         given(jwtTokenProvider.validateToken(token)).willReturn(true);
         given(jwtTokenProvider.getUserIdFromToken(token)).willReturn(userId);


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #71 

## 📝 작업 내용
- 회원 관심사 등록 API 구현
  - 회원 가입 후 초기 관심사 등록 기능
  - 등록 완료 시 회원 상태를 'COMPLETED'로 변경
- 회원 관심사 수정 API 구현
  - 기존 관심사 삭제 후 새로운 관심사로 대체

## 🎸 기타 (선택)
`관심 분야`를 수정할 때 delete-insert 방식 `성능 이슈 발생 시` 변경된 부분만 업데이트 할 수 있도록
