### PR TITLE
feat: OAuth 인증 후 JWT 토큰을 쿠키에 저장하도록 변경 (#93)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -6,23 +6,33 @@ import com.blooming.inpeak.auth.utils.JwtTokenProvider;
 import com.blooming.inpeak.member.domain.Member;
 import com.blooming.inpeak.member.dto.MemberPrincipal;
 import com.blooming.inpeak.member.repository.MemberRepository;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    public static String REDIRECT_URL = "http://localhost:8080/";
-    public static Duration ACCESS_TOKEN_DURATION = Duration.ofMinutes(30);
-    public static Duration REFRESH_TOKEN_DURATION = Duration.ofDays(14);
+    @Value("${jwt.redirectUri}")
+    private String redirectUrl;
+
+    @Value("${jwt.accessToken.expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refreshToken.expiration}")
+    private long refreshTokenExpiration;
+
+    // 쿠키 관련 상수 추가
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
@@ -34,26 +44,36 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         HttpServletResponse response,
         Authentication authentication
     ) throws IOException {
-
         MemberPrincipal oAuth2User = (MemberPrincipal) authentication.getPrincipal();
         Member member = memberRepository.findByKakaoId(oAuth2User.kakaoId())
             .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
-        String accessToken = jwtTokenProvider.makeToken(member, ACCESS_TOKEN_DURATION);
-        String refreshToken = jwtTokenProvider.makeToken(member, REFRESH_TOKEN_DURATION);
+        Duration accessTokenDuration = Duration.ofMillis(accessTokenExpiration);
+        Duration refreshTokenDuration = Duration.ofMillis(refreshTokenExpiration);
+
+        String accessToken = jwtTokenProvider.makeToken(member, accessTokenDuration);
+        String refreshToken = jwtTokenProvider.makeToken(member, refreshTokenDuration);
 
         storeOrGenerate(member, refreshToken);
 
-        //리다이렉트 URL 생성, 차후에 쿠키 방식으로 리펙토링
-        String redirectUrl = ServletUriComponentsBuilder
-            .fromUriString(REDIRECT_URL)
-            .queryParam("accessToken", accessToken)
-            .queryParam("refreshToken", refreshToken)
-            .build()
-            .toUriString();
+        // 토큰을 쿠키에 저장
+        addTokenCookie(
+            response, ACCESS_TOKEN_COOKIE_NAME, accessToken, (int) accessTokenDuration.toSeconds()
+        );
+        addTokenCookie(
+            response, REFRESH_TOKEN_COOKIE_NAME, refreshToken, (int) refreshTokenDuration.toSeconds()
+        );
 
-        getRedirectStrategy()
-            .sendRedirect(request, response, redirectUrl);
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+
+    private void addTokenCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+//        cookie.setSecure(true); // HTTPS 환경에서만 활성화
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
     }
 
     private void storeOrGenerate(Member member, String refreshToken) {

--- a/inpeak/src/main/resources/application.yml
+++ b/inpeak/src/main/resources/application.yml
@@ -15,8 +15,12 @@ spring:
 
 jwt:
   secret: ${SECRET_KEY:your-secret-key-should-be-at-least-32-characters-long}
-  expiration: ${EXPIRATION_TIME:86400000}
+  accessToken:
+    expiration: ${EXPIRATION_TIME:86400000}
+  refreshToken:
+    expiration: ${REFRESH_EXPIRATION_TIME:1209600000}
   issuer: ${ISSUER:inpeak}
+  redirectUri: ${REDIRECT_URL:"http://localhost:5173/interview/"}
 
 server:
   tomcat:


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #93 

## 📝 작업 내용
- OAuth2AuthenticationSuccessHandler 수정하여 JWT 토큰을 쿠키에 저장
- Access Token과 Refresh Token을 HttpOnly 쿠키로 설정
- 토큰 만료 시간을 쿠키에 반영

## 🎸 기타 (선택)

## 💬 리뷰 요구사항(선택)
