### PR TITLE
feat: 대시보드에 정답률 비교 추가 (#97)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/answer/repository/AnswerRepository.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/repository/AnswerRepository.java
@@ -53,4 +53,30 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
         "WHERE a.id = :answerId")
     Optional<Answer> findAnswerById(@Param("answerId") Long answerId);
 
+    /**
+     * 특정 회원의 답변 성공률을 계산하는 쿼리
+     * SKIPPED 상태의 답변은 제외하고 계산
+     */
+    @Query("""
+    SELECT COALESCE(
+        CAST(SUM(CASE WHEN a.status = 'CORRECT' THEN 1 ELSE 0 END) * 100 AS INTEGER) / 
+        NULLIF(CAST(SUM(CASE WHEN a.status IN ('CORRECT', 'INCORRECT') THEN 1 ELSE 0 END) AS INTEGER), 0),
+        0)
+    FROM Answer a
+    WHERE a.memberId = :memberId
+    """)
+    int getMemberSuccessRate(@Param("memberId") Long memberId);
+
+    /**
+     * 전체 사용자의 평균 답변 성공률을 계산하는 쿼리
+     * SKIPPED 상태의 답변은 제외하고 계산
+     */
+    @Query("""
+    SELECT COALESCE(
+        CAST(SUM(CASE WHEN a.status = 'CORRECT' THEN 1 ELSE 0 END) * 100 AS INTEGER) / 
+        NULLIF(CAST(SUM(CASE WHEN a.status IN ('CORRECT', 'INCORRECT') THEN 1 ELSE 0 END) AS INTEGER), 0),
+        0)
+    FROM Answer a
+    """)
+    int getAverageSuccessRate();
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/dashborad/dto/InterviewDashboardResponse.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/dashborad/dto/InterviewDashboardResponse.java
@@ -1,7 +1,6 @@
 package com.blooming.inpeak.dashborad.dto;
 
 import com.blooming.inpeak.answer.dto.response.MemberLevelResponse;
-import com.blooming.inpeak.answer.dto.response.RecentAnswerListResponse;
 import com.blooming.inpeak.answer.dto.response.RecentAnswerResponse;
 import com.blooming.inpeak.interview.dto.response.RemainingInterviewsResponse;
 import java.util.List;
@@ -9,16 +8,19 @@ import lombok.Builder;
 
 @Builder
 public record InterviewDashboardResponse(RemainingInterviewsResponse remainingInterviews,
+                                         SuccessRateResponse successRate,
                                          MemberLevelResponse levelInfo,
                                          List<RecentAnswerResponse> recentAnswers) {
 
     public static InterviewDashboardResponse of(
         RemainingInterviewsResponse remainingInterviews,
+        SuccessRateResponse successRate,
         MemberLevelResponse levelInfo,
         List<RecentAnswerResponse> recentAnswers
     ) {
         return InterviewDashboardResponse.builder()
             .remainingInterviews(remainingInterviews)
+            .successRate(successRate)
             .levelInfo(levelInfo)
             .recentAnswers(recentAnswers)
             .build();

--- a/inpeak/src/main/java/com/blooming/inpeak/dashborad/dto/SuccessRateResponse.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/dashborad/dto/SuccessRateResponse.java
@@ -1,0 +1,16 @@
+package com.blooming.inpeak.dashborad.dto;
+
+import lombok.Builder;
+
+@Builder
+public record SuccessRateResponse(
+    int userSuccessRate,
+    int averageSuccessRate
+) {
+    public static SuccessRateResponse of(int userSuccessRate, int averageSuccessRate) {
+        return SuccessRateResponse.builder()
+            .userSuccessRate(userSuccessRate)
+            .averageSuccessRate(averageSuccessRate)
+            .build();
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/dashborad/service/InterviewDashboardService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/dashborad/service/InterviewDashboardService.java
@@ -6,6 +6,7 @@ import com.blooming.inpeak.answer.dto.response.RecentAnswerListResponse;
 import com.blooming.inpeak.answer.dto.response.RecentAnswerResponse;
 import com.blooming.inpeak.answer.service.AnswerService;
 import com.blooming.inpeak.dashborad.dto.InterviewDashboardResponse;
+import com.blooming.inpeak.dashborad.dto.SuccessRateResponse;
 import com.blooming.inpeak.interview.dto.response.RemainingInterviewsResponse;
 import com.blooming.inpeak.interview.service.InterviewService;
 import java.time.LocalDate;
@@ -21,6 +22,7 @@ public class InterviewDashboardService {
 
     private final InterviewService interviewService;
     private final AnswerService answerService;
+    private final SuccessRateService successRateService;
 
     public InterviewDashboardResponse getDashboard(Long memberId, LocalDate startDate) {
         RemainingInterviewsResponse remainingInterviews =
@@ -29,7 +31,9 @@ public class InterviewDashboardService {
         RecentAnswerListResponse recentAnswerList =
             answerService.getRecentAnswers(memberId, AnswerStatus.ALL);
         List<RecentAnswerResponse> recentAnswers = recentAnswerList.recentAnswers();
+        SuccessRateResponse successRate = successRateService.getSuccessRate(memberId);
 
-        return InterviewDashboardResponse.of(remainingInterviews, levelInfo, recentAnswers);
+        return InterviewDashboardResponse.of(
+            remainingInterviews, successRate, levelInfo, recentAnswers);
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/dashborad/service/SuccessRateService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/dashborad/service/SuccessRateService.java
@@ -1,0 +1,22 @@
+package com.blooming.inpeak.dashborad.service;
+
+import com.blooming.inpeak.answer.repository.AnswerRepository;
+import com.blooming.inpeak.dashborad.dto.SuccessRateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SuccessRateService {
+
+    private final AnswerRepository answerRepository;
+
+    public SuccessRateResponse getSuccessRate(Long memberId) {
+        return SuccessRateResponse.of(
+            answerRepository.getMemberSuccessRate(memberId),
+            answerRepository.getAverageSuccessRate()
+        );
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #97 

## 📝 작업 내용
- 사용자별 정답률 계산 쿼리 추가
- 전체 사용자 평균 정답률 계산 쿼리 추가
- SuccessRateService 생성 및 구현
- 대시보드 응답에 성공률 정보 포함
- 성공률 계산 시 건너뛴 답변(SKIPPED) 제외 처리