### PR TITLE
feat: 회원 탈퇴 시 S3에 저장된 모의면접 영상 삭제 기능 구현 (#103)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
@@ -53,6 +53,7 @@ public class Answer extends BaseEntity {
 
     private String userAnswer;
 
+    @Column(name = "video_url")
     private String videoURL;
 
     private Long runningTime;

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/repository/AnswerRepository.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/repository/AnswerRepository.java
@@ -81,4 +81,10 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     int getAverageSuccessRate();
 
     void deleteByMemberId(Long id);
+
+    /**
+     * 특정 멤버의 모든 비디오 URL 조회
+     */
+    @Query(value = "SELECT video_url FROM answer WHERE member_id = :memberId", nativeQuery = true)
+    List<String> findAllVideoUrlsByMemberId(@Param("memberId") Long memberId);
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerPresignedUrlService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerPresignedUrlService.java
@@ -74,7 +74,7 @@ public class AnswerPresignedUrlService {
      * @param memberId  사용자 ID
      * @param startDate 인터뷰 시작 날짜
      * @param extension 확장자 (예: "mp4")
-     * @return "videos/123/20250228/uuid.extension" 형태의 파일명
+     * @return "videos/123/250228/uuid.extension" 형태의 파일명
      */
     private String generateObjectKey(Long memberId, LocalDate startDate, String extension) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMdd");

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerVideoCleanupService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerVideoCleanupService.java
@@ -1,0 +1,66 @@
+package com.blooming.inpeak.answer.service;
+
+import com.blooming.inpeak.answer.repository.AnswerRepository;
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnswerVideoCleanupService {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AnswerRepository answerRepository;
+    private final S3Client s3Client;
+
+    /**
+     * 특정 회원의 모든 S3 객체 삭제
+     *
+     * @param memberId 회원 ID
+     */
+    public void deleteAllS3Objects(Long memberId) {
+        List<String> videoUrls = answerRepository.findAllVideoUrlsByMemberId(memberId);
+
+        if (videoUrls.isEmpty()) {
+            return;
+        }
+
+        // S3 키 추출 후 객체 삭제
+        List<ObjectIdentifier> objectsToDelete = videoUrls.stream()
+            .map(this::extractObjectKey)
+            .map(key -> ObjectIdentifier.builder().key(key).build())
+            .collect(Collectors.toList());
+
+        try {
+            DeleteObjectsRequest deleteRequest = DeleteObjectsRequest.builder()
+                .bucket(bucket)
+                .delete(Delete.builder().objects(objectsToDelete).build())
+                .build();
+            s3Client.deleteObjects(deleteRequest);
+        } catch (S3Exception e) {
+            throw new RuntimeException("S3 객체 삭제에 실패했습니다.", e);
+        }
+    }
+
+    // S3 URL에서 객체 키 추출
+    private String extractObjectKey(String s3Url) {
+        try {
+            URI uri = new URI(s3Url);
+            return uri.getPath().substring(1);
+        } catch (Exception e) {
+            throw new RuntimeException("S3 URL 형식이 알맞지 않습니다: " + s3Url, e);
+        }
+    }
+}

--- a/inpeak/src/main/java/com/blooming/inpeak/member/service/MemberService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.blooming.inpeak.member.service;
 
 import com.blooming.inpeak.answer.repository.AnswerRepository;
+import com.blooming.inpeak.answer.service.AnswerVideoCleanupService;
 import com.blooming.inpeak.auth.repository.RefreshTokenRepository;
 import com.blooming.inpeak.interview.repository.InterviewRepository;
 import com.blooming.inpeak.member.domain.Member;
@@ -19,6 +20,7 @@ public class MemberService {
     private final InterviewRepository interviewRepository;
     private final MemberInterestRepository memberInterestRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final AnswerVideoCleanupService answerVideoCleanupService;
 
     @Transactional
     public String updateNickName(Long memberId, String nickName) {
@@ -44,5 +46,6 @@ public class MemberService {
         memberInterestRepository.deleteByMemberId(id);
         refreshTokenRepository.deleteByMemberId(id);
         memberRepository.delete(member);
+        answerVideoCleanupService.deleteAllS3Objects(id);
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈

- close #103 

## 📝 작업 내용

- 회원 탈퇴 시, S3에 저장되어 있는 회원의 모든 모의면접 영상을 삭제하는 기능을 구현했습니다.

## 🎸 기타 (선택)
> 고려해야 하는 내용을 작성해 주세요.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
