### PR TITLE
feat: Member 엔티티에 이메일 정보 저장 기능 추가 (#107)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
@@ -44,12 +44,15 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private RegistrationStatus registrationStatus;
 
+    @Column(nullable = false)
+    private String kakaoEmail;
+
     @Builder
     private Member(
         Long id,
         Long kakaoId, String nickname, Long totalQuestionCount,
         Long correctAnswerCount, OAuth2Provider provider,
-        RegistrationStatus registrationStatus
+        RegistrationStatus registrationStatus, String kakaoEmail
     ) {
         this.id = id;
         this.kakaoId = kakaoId;
@@ -59,13 +62,15 @@ public class Member extends BaseEntity {
         this.provider = provider;
         this.registrationStatus =
             registrationStatus != null ? registrationStatus : RegistrationStatus.INITIATED;
+        this.kakaoEmail = kakaoEmail;
     }
 
     // 테스트 파일에서 사용할 생성자
     @Builder(access = AccessLevel.PRIVATE)
     public Member(
         Long id, Long kakaoId, String nickname,
-        OAuth2Provider provider, RegistrationStatus registrationStatus
+        OAuth2Provider provider, RegistrationStatus registrationStatus,
+        String kakaoEmail
     ) {
         this.id = id;
         this.kakaoId= kakaoId;
@@ -73,10 +78,11 @@ public class Member extends BaseEntity {
         this.provider = provider;
         this.registrationStatus =
             registrationStatus != null ? registrationStatus : RegistrationStatus.INITIATED;
+        this.kakaoEmail = kakaoEmail;
     }
 
     public static Member of(
-        Long kakaoId, String nickname,
+        Long kakaoId, String nickname, String kakaoEmail,
         OAuth2Provider provider, RegistrationStatus registrationStatus
     ) {
         return Member.builder()
@@ -85,6 +91,7 @@ public class Member extends BaseEntity {
             .provider(provider)
             .registrationStatus(
                 registrationStatus != null ? registrationStatus : RegistrationStatus.INITIATED)
+            .kakaoEmail(kakaoEmail)
             .build();
     }
 

--- a/inpeak/src/test/java/com/blooming/inpeak/answer/repository/AnswerRepositoryCustomTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/answer/repository/AnswerRepositoryCustomTest.java
@@ -52,6 +52,7 @@ class AnswerRepositoryCustomTest {
             Member.of(
                 1234567890L,
                 "테스트 닉네임",
+                "test@test.com",
                 OAuth2Provider.KAKAO,
                 RegistrationStatus.COMPLETED
             )

--- a/inpeak/src/test/java/com/blooming/inpeak/auth/service/CustomOAuth2UserServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/auth/service/CustomOAuth2UserServiceTest.java
@@ -63,8 +63,10 @@ class CustomOAuth2UserServiceTest {
     @DisplayName("기존 회원 로드 성공")
     void loadExistingUser() {
         // given
+        String testEmail = "test@test.com";
         Long kakaoId = 12345678L;
         Member existingMember = Member.builder()
+            .kakaoEmail(testEmail)
             .kakaoId(kakaoId)
             .nickname("기존회원")
             .provider(OAuth2Provider.KAKAO)
@@ -74,6 +76,7 @@ class CustomOAuth2UserServiceTest {
 
         // 테스트 데이터 설정
         Map<String, Object> kakaoAccount = new HashMap<>();
+        kakaoAccount.put("email", testEmail);
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("id", kakaoId);
@@ -131,6 +134,7 @@ class CustomOAuth2UserServiceTest {
         Long kakaoId = 12345678L;
         String generatedNickname = "신규닉네임123";
         String tokenValue = "new-token-value";
+        String testEmail = "test@test.com";
 
         Member newMember = Member.builder()
             .kakaoId(kakaoId)
@@ -138,10 +142,12 @@ class CustomOAuth2UserServiceTest {
             .provider(OAuth2Provider.KAKAO)
             .totalQuestionCount(0L)
             .correctAnswerCount(0L)
+            .kakaoEmail(testEmail)
             .build();
 
         // 테스트 데이터 설정
         Map<String, Object> kakaoAccount = new HashMap<>();
+        kakaoAccount.put("email", testEmail);
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("id", kakaoId);

--- a/inpeak/src/test/java/com/blooming/inpeak/member/repository/MemberRepositoryTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/member/repository/MemberRepositoryTest.java
@@ -30,12 +30,14 @@ class MemberRepositoryTest extends IntegrationTestSupport {
     void findByEmail() {
         // given
         Long kakaoId = 1234567890L;
+        String testEmail = "test@test.com";
         Member member = Member.builder()
             .kakaoId(kakaoId)
             .nickname("테스트유저")
             .provider(OAuth2Provider.KAKAO)
             .totalQuestionCount(0L)
             .correctAnswerCount(0L)
+            .kakaoEmail(testEmail)
             .build();
         memberRepository.save(member);
 
@@ -54,12 +56,15 @@ class MemberRepositoryTest extends IntegrationTestSupport {
         //given
         Long kakaoId = 1234567890L;
         String nickname = "유니크 닉네임";
+        String testEmail = "test@test.com";
+
         Member member = Member.builder()
             .kakaoId(kakaoId)
             .nickname(nickname)
             .provider(OAuth2Provider.KAKAO)
             .totalQuestionCount(0L)
             .correctAnswerCount(0L)
+            .kakaoEmail(testEmail)
             .build();
         memberRepository.save(member);
 


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #107 

## 📝 작업 내용
- Member 엔티티에 kakaoEmail 필드 추가
- OAuth2 인증 과정에서 카카오 계정의 이메일 정보 추출 및 저장
- 회원 가입 과정에서 이메일 정보 저장 로직 수정
- 관련 생성자 및 팩토리 메서드 수정
