### PR TITLE
refactor: 회원 레벨 정책 변경 (#105)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
@@ -201,12 +201,11 @@ public class AnswerService {
             stats.incorrectAnswerCount().intValue());
         int level = calculateLevel(exp);
 
-        boolean isMaxLevel = (level == MAX_LEVEL);
-        int baseIndex = isMaxLevel ? (level - 2) : (level - 1);
-        int topIndex = isMaxLevel ? (level - 1) : level;
+        if (level == 0) return MemberLevelResponse.of(0, 0, 0);
 
-        int currentExp = exp - LEVEL_EXP_TABLE[baseIndex];
-        int nextExp = LEVEL_EXP_TABLE[topIndex] - LEVEL_EXP_TABLE[baseIndex];
+        int currentExp = exp - LEVEL_EXP_TABLE[level - 1];
+        int nextExp = (level == MAX_LEVEL) ?
+            0 : LEVEL_EXP_TABLE[level] - LEVEL_EXP_TABLE[level - 1];
 
         return MemberLevelResponse.of(level, currentExp, nextExp);
     }
@@ -218,6 +217,8 @@ public class AnswerService {
     }
 
     private int calculateLevel(int exp) {
+        if (exp == 0) return 0;
+
         double val = (1 + Math.sqrt(1 + (4.0 * exp / 15.0))) / 2.0;
         int level = (int) Math.floor(val);
 

--- a/inpeak/src/test/java/com/blooming/inpeak/answer/service/AnswerServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/answer/service/AnswerServiceTest.java
@@ -359,9 +359,9 @@ class AnswerServiceTest extends IntegrationTestSupport {
         MemberLevelResponse response = answerService.getMemberLevel(memberId);
 
         // then
-        assertThat(response.level()).isEqualTo(1);
+        assertThat(response.level()).isEqualTo(0);
         assertThat(response.currentExp()).isEqualTo(0);
-        assertThat(response.nextExp()).isEqualTo(30);
+        assertThat(response.nextExp()).isEqualTo(0);
     }
 
     @DisplayName("getMemberLevel()은 경험치 40일 때 올바른 레벨 정보를 반환해야 한다.")
@@ -422,7 +422,7 @@ class AnswerServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(response.level()).isEqualTo(10);
-        assertThat(response.currentExp()).isEqualTo(275);
-        assertThat(response.nextExp()).isEqualTo(270);
+        assertThat(response.currentExp()).isEqualTo(5);
+        assertThat(response.nextExp()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈

- close #105 

## 📝 작업 내용

- 회원가입만 한 상태인 0레벨을 추가했습니다.
- 최대 레벨일 때, 경험치 정책이 변경되었습니다.
  - 10 레벨 달성 시, 다음 레벨업에 필요한 경험치가 0으로 표시됩니다.
  - 10 레벨 달성 시, 9 레벨의 최대 경험치인 270부터 누적되던 것을 0부터 누적되는 것으로 변경했습니다.
  - ex. 10 레벨 (275 exp) -> 10 레벨 (5 exp)

## 🎸 기타 (선택)
> 

## 💬 리뷰 요구사항(선택)

> 
