### PR TITLE
feat: 인증 방식을 쿠키 기반으로 전환 (#121)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/auth/controller/AuthController.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/controller/AuthController.java
@@ -3,10 +3,11 @@ package com.blooming.inpeak.auth.controller;
 import com.blooming.inpeak.auth.dto.TokenResponse;
 import com.blooming.inpeak.auth.service.AuthService;
 import com.blooming.inpeak.member.dto.MemberPrincipal;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,38 +25,25 @@ public class AuthController {
 
     @GetMapping("/test")
     public String test(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-        System.out.println("member = " + memberPrincipal.kakaoId());
         return memberPrincipal.toString();
     }
 
-    // TODO: Authentication 객체를 사용하는 것이 좋을까요? @AuthenticationPrincipal 애너테이션을 사용하는 것이 좋을까요?
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(Authentication authentication) {
-        MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
-
-        authService.logout(principal.id());
+    public ResponseEntity<Void> logout(
+        @AuthenticationPrincipal MemberPrincipal principal,
+        HttpServletResponse response
+    ) {
+        authService.logout(principal.id(), response);
         return ResponseEntity.ok().build();
     }
 
-    // 토큰 재발급 엔드포인트 추가
     @PostMapping("/reissue")
-    public ResponseEntity<TokenResponse> reissueToken(HttpServletRequest request, HttpServletResponse response) {
-        TokenResponse tokenResponse = authService.reissueToken(request);
-
-        addTokenCookie(response, "accessToken", tokenResponse.accessToken(),
-            (int)(tokenResponse.accessTokenExpiresIn() / 1000));
-        addTokenCookie(response, "refreshToken", tokenResponse.refreshToken(),
-            (int)(tokenResponse.refreshTokenExpiresIn() / 1000));
+    public ResponseEntity<TokenResponse> reissueToken(
+        HttpServletRequest request,
+        HttpServletResponse response
+    ) {
+        TokenResponse tokenResponse = authService.reissueToken(request, response);
 
         return ResponseEntity.ok(tokenResponse);
-    }
-
-    private void addTokenCookie(HttpServletResponse response, String name, String value, int maxAge) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-//        cookie.setSecure(true); // HTTPS 환경에서만 활성화 // TODO: 어떻게 하는 것이 좋을까?
-        cookie.setMaxAge(maxAge);
-        response.addCookie(cookie);
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilter.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/filter/TokenAuthenticationFilter.java
@@ -1,20 +1,24 @@
 package com.blooming.inpeak.auth.filter;
 
+import com.blooming.inpeak.auth.repository.RefreshTokenRepository;
 import com.blooming.inpeak.auth.utils.JwtTokenProvider;
 import com.blooming.inpeak.member.domain.Member;
 import com.blooming.inpeak.member.dto.MemberPrincipal;
 import com.blooming.inpeak.member.repository.MemberRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -25,17 +29,20 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
-    private final static String HEADER_AUTHORIZATION = "Authorization";
-    private final static String TOKEN_PREFIX = "Bearer ";
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
-    // 회원 등록 관련 경로 상수로 정의
     private final List<String> REGISTRATION_PATHS = List.of(
-        "/interest",
-        "/interest/list",
-        "/auth/logout"
+        "/api/interest",
+        "/api/interest/list",
+        "/api/auth/logout",
+        "/api/auth/reissue",
+        "/api/auth/test"
     );
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
     @Override
     protected void doFilterInternal(
@@ -43,54 +50,146 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         HttpServletResponse response,
         FilterChain filterChain
     ) throws IOException, ServletException {
+        String accessToken = getCookie(request, ACCESS_TOKEN_COOKIE_NAME);
+        String refreshToken = getCookie(request, REFRESH_TOKEN_COOKIE_NAME);
 
-        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
-
-        // 토큰이 없거나 형식이 맞지 않을 경우
-        if (authorizationHeader == null || !authorizationHeader.startsWith(TOKEN_PREFIX)) {
-            sendErrorResponse(response, "헤더에 액세스 토큰이 없거나, Bearer 접두어가 빠져있습니다");
+        // accessToken이 없는 경우
+        if (accessToken == null) {
+            sendErrorResponse(response, "accessToken이 없습니다");
             return;
         }
 
-        String token = authorizationHeader.substring(TOKEN_PREFIX.length());
-
-        // 토큰 검증 실패 시
-        if (!jwtTokenProvider.validateToken(token)) {
-            sendErrorResponse(response, "유효하지 않은 토큰입니다");
+        // 유효한 토큰(accessToken, refreshToken)에서 userId 추출. (accessToken이 만료되었다면 갱신 시도)
+        String userId = getUserIdFromTokens(accessToken, refreshToken, response);
+        if (userId == null) {
             return;
         }
 
-        // 토큰이 유효한 경우, 사용자 정보 설정 추가 필요
-        String userId = jwtTokenProvider.getUserIdFromToken(token);
+        // 3. 사용자 조회
+        Member member = findMemberById(userId, response);
+        if (member == null) {
+            return;
+        }
+
+        // 4. 등록 미완료 회원 접근 제한
+        if (!isAccessiblePath(request, member)) {
+            sendRegistrationErrorResponse(response, "가입이 완료되지 않은 사용자입니다");
+            return;
+        }
+
+        // 5. 인증 객체 설정 및 다음 필터 실행
+        authenticateUser(member);
+        filterChain.doFilter(request, response);
+    }
+
+    private String getUserIdFromTokens(
+        String accessToken, String refreshToken, HttpServletResponse response
+    ) throws IOException {
+        // 액세스 토큰이 유효한 경우
+        if (jwtTokenProvider.validateToken(accessToken)) {
+            return jwtTokenProvider.getUserIdFromToken(accessToken);
+        }
+
+        // 액세스 토큰 만료, 리프레시 토큰 확인
+        log.debug("Access token 만료됨, refresh token으로 갱신 시도");
+
+        // 리프레시 토큰이 없거나 유효하지 않은 경우
+        if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken)) {
+            sendErrorResponse(response, "accessToken이 만료되었고, refreshToken도 유효하지 않습니다");
+            return null;
+        }
+
+        // 리프레시 토큰을 사용하여 사용자 ID 획득 및 액세스 토큰 갱신
+        String userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+        reissueAccessToken(userId, response);
+
+        return userId;
+    }
+
+    private void reissueAccessToken(String userId, HttpServletResponse response) throws IOException {
         Optional<Member> optionalMember = memberRepository.findById(Long.valueOf(userId));
 
         if (optionalMember.isEmpty()) {
-            sendErrorResponse(response, "사용자를 찾을 수 없습니다");
+            sendErrorResponse(response, "refreshToken의 사용자 정보를 찾을 수 없습니다");
             return;
         }
 
         Member member = optionalMember.get();
 
-        // 현재 요청 경로가 회원 등록 관련 경로인지 확인
-        String path = request.getServletPath();
-        boolean isRegistrationRelatedPath = REGISTRATION_PATHS.stream()
-            .anyMatch(path::startsWith);
+        // Access Token 재발급 - 1시간
+        String newAccessToken = jwtTokenProvider.makeToken(member, Duration.ofHours(1));
 
-        // 회원 등록이 완료되지 않았고, 현재 경로가 등록 관련 경로가 아닐 경우에만 488 오류 반환
-        if (!member.registrationCompleted() && !isRegistrationRelatedPath) {
-            sendRegistrationErrorResponse(response, "가입이 완료되지 않은 사용자입니다");
-            return;
+        // Refresh Token 재발급 - 14일
+        Duration refreshTokenDuration = Duration.ofDays(14);
+        String newRefreshToken = jwtTokenProvider.makeToken(member, refreshTokenDuration);
+
+        updateRefreshTokenInDb(member.getId(), newRefreshToken);
+
+        addTokenCookie(response, ACCESS_TOKEN_COOKIE_NAME, newAccessToken, Duration.ofHours(1).toSeconds());
+        addTokenCookie(response, REFRESH_TOKEN_COOKIE_NAME, newRefreshToken, refreshTokenDuration.toSeconds());
+    }
+
+    private void addTokenCookie(HttpServletResponse response, String name, String value, long maxAge) {
+        ResponseCookie responseCookie = ResponseCookie.from(name, value)
+            .path("/")
+            .httpOnly(true)
+            .maxAge(maxAge)
+            .sameSite("Strict")
+            .secure(true)
+            .build();
+        response.addHeader("Set-Cookie", responseCookie.toString());
+    }
+
+    private void updateRefreshTokenInDb(Long memberId, String newRefreshToken) {
+        refreshTokenRepository.findByMemberId(memberId)
+            .ifPresent(token -> {
+                token.update(newRefreshToken);
+                refreshTokenRepository.save(token);
+            });
+    }
+
+    private Member findMemberById(String userId, HttpServletResponse response) throws IOException {
+        Optional<Member> optionalMember = memberRepository.findById(Long.valueOf(userId));
+
+        if (optionalMember.isEmpty()) {
+            sendErrorResponse(response, "사용자를 찾을 수 없습니다");
+            return null;
         }
 
-        // 인증 객체 생성 및 설정
-        MemberPrincipal memberPrincipal = MemberPrincipal.create(member, null); // 속성은 필요에 따라 조정
+        return optionalMember.get();
+    }
+
+    private boolean isAccessiblePath(HttpServletRequest request, Member member) {
+        // 회원이 등록 완료 상태라면 모든 경로 접근 가능
+        if (member.registrationCompleted()) {
+            return true;
+        }
+
+        // 등록 미완료 회원은 허용된 경로만 접근 가능
+        String path = request.getServletPath();
+        return REGISTRATION_PATHS.stream()
+            .anyMatch(path::startsWith);
+    }
+
+    private void authenticateUser(Member member) {
+        MemberPrincipal memberPrincipal = MemberPrincipal.create(member, null);
         UsernamePasswordAuthenticationToken authentication =
             new UsernamePasswordAuthenticationToken(
-                memberPrincipal, null, memberPrincipal.getAuthorities());
+                memberPrincipal, null, memberPrincipal.getAuthorities()
+            );
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
 
-        filterChain.doFilter(request, response);
+    private String getCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (name.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 
     private void sendErrorResponse(HttpServletResponse response, String message) throws IOException {
@@ -98,22 +197,14 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write("{\"message\":\"" + message + "\"}");
-
-        if (log.isErrorEnabled()) {
-            log.error("인증 필터에서 요청이 중단됨: {}", message);
-        }
+        log.error("인증 실패: {}", message);
     }
 
-    private void sendRegistrationErrorResponse(
-        HttpServletResponse response, String message
-    ) throws IOException {
+    private void sendRegistrationErrorResponse(HttpServletResponse response, String message) throws IOException {
         response.setStatus(488);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write("{\"message\":\"" + message + "\"}");
-
-        if (log.isErrorEnabled()) {
-            log.error("가입이 완료되지 않은 사용자입니다: {}", message);
-        }
+        log.error("가입 미완료 사용자 차단: {}", message);
     }
 }

--- a/inpeak/src/main/java/com/blooming/inpeak/auth/service/AuthService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/service/AuthService.java
@@ -8,9 +8,12 @@ import com.blooming.inpeak.member.domain.Member;
 import com.blooming.inpeak.member.repository.MemberRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +28,7 @@ public class AuthService {
     @Value("${jwt.refreshToken.expiration}")
     private long refreshTokenExpiration;
 
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
     private final RefreshTokenRepository refreshTokenRepository;
@@ -32,19 +36,25 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
-    public void logout(Long memberId) {
+    public void logout(Long memberId, HttpServletResponse response) {
+        // DB에서 리프레시 토큰 삭제
         refreshTokenRepository.deleteByMemberId(memberId);
+
+        // 쿠키 무효화
+        removeTokenCookies(response);
     }
 
+    /**
+     * 토큰 재발급 - 리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰 발급
+     */
     @Transactional
-    public TokenResponse reissueToken(HttpServletRequest request) {
-        String authorizationHeader = request.getHeader("Authorization");
-        String refreshTokenValue = null;
+    public TokenResponse reissueToken(HttpServletRequest request, HttpServletResponse response) {
+        // 쿠키에서 리프레시 토큰 추출
+        String refreshTokenValue = extractTokenFromCookie(request);
 
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            refreshTokenValue = authorizationHeader.substring(7);
-        } else {
-            refreshTokenValue = extractRefreshTokenFromCookie(request);
+        // 쿠키가 없는 경우(이전 버전 호환성) Authorization 헤더 확인
+        if (refreshTokenValue == null) {
+            refreshTokenValue = extractTokenFromAuthHeader(request);
         }
 
         if (refreshTokenValue == null) {
@@ -52,23 +62,37 @@ public class AuthService {
         }
 
         if (!jwtTokenProvider.validateToken(refreshTokenValue)) {
+            // 쿠키 무효화 후 예외 발생
+            removeTokenCookies(response);
             throw new IllegalArgumentException("유효하지 않은 Refresh 토큰입니다.");
         }
 
         RefreshToken refreshToken = refreshTokenRepository.findByRefreshToken(refreshTokenValue)
-            .orElseThrow(() -> new IllegalArgumentException("저장된 Refresh 토큰이 존재하지 않습니다."));
+            .orElseThrow(() -> {
+                removeTokenCookies(response); // 쿠키 무효화
+                return new IllegalArgumentException("저장된 Refresh 토큰이 존재하지 않습니다.");
+            });
 
         Member member = memberRepository.findById(refreshToken.getMemberId())
-            .orElseThrow(() -> new IllegalArgumentException("회원 정보가 존재하지 않습니다."));
+            .orElseThrow(() -> {
+                removeTokenCookies(response); // 쿠키 무효화
+                return new IllegalArgumentException("회원 정보가 존재하지 않습니다.");
+            });
 
+        // 새로운 토큰 발급
         Duration accessTokenDuration = Duration.ofMillis(accessTokenExpiration);
         Duration refreshTokenDuration = Duration.ofMillis(refreshTokenExpiration);
 
         String newAccessToken = jwtTokenProvider.makeToken(member, accessTokenDuration);
         String newRefreshToken = jwtTokenProvider.makeToken(member, refreshTokenDuration);
 
+        // DB에 새로운 리프레시 토큰 저장
         refreshToken.update(newRefreshToken);
         refreshTokenRepository.save(refreshToken);
+
+        // 쿠키에 새로운 토큰 저장
+        addTokenCookie(response, ACCESS_TOKEN_COOKIE_NAME, newAccessToken, accessTokenDuration.toSeconds());
+        addTokenCookie(response, REFRESH_TOKEN_COOKIE_NAME, newRefreshToken, refreshTokenDuration.toSeconds());
 
         return new TokenResponse(
             newAccessToken,
@@ -78,15 +102,58 @@ public class AuthService {
         );
     }
 
-    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+    private String extractTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                if (AuthService.REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
                     return cookie.getValue();
                 }
             }
         }
         return null;
+    }
+
+    /**
+     * Authorization 헤더에서 토큰 추출 (이전 버전 호환성)
+     */
+    private String extractTokenFromAuthHeader(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            return authorizationHeader.substring(7);
+        }
+        return null;
+    }
+
+    /**
+     * 쿠키 설정 - ResponseCookie 사용
+     */
+    private void addTokenCookie(HttpServletResponse response, String name, String value, long maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+            .path("/")
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("Strict")
+            .maxAge(maxAge)
+            .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    /**
+     * 쿠키 무효화 - 만료 처리
+     */
+    private void removeTokenCookies(HttpServletResponse response) {
+        ResponseCookie accessTokenCookie = ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, "")
+            .path("/")
+            .maxAge(0)
+            .build();
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+            .path("/")
+            .maxAge(0)
+            .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #121 

## 📝 작업 내용
- 엑세스 토큰과 리스레시 토큰을 HttpOnly, Secure, SameSite 속성을 추가한 쿠키로 관리
- Bearer 토큰 방식과의 하위 호환성 유지 (access는 Bearer 헤더로 변경 가능)
- TokenAuthenticationFilter에서 쿠키 기반 인증 처리 구현
