### PR TITLE
feat: 토큰 인증 필터 접근 제어 로직 개선 (#134)

### DIFF
--- a/inpeak/src/main/resources/application.yml
+++ b/inpeak/src/main/resources/application.yml
@@ -20,7 +20,7 @@ jwt:
   refreshToken:
     expiration: ${REFRESH_EXPIRATION_TIME:1209600000}
   issuer: ${ISSUER:inpeak}
-  redirectUri: ${REDIRECT_URL:http://localhost:5173/?status=NEED_MORE_INFO}
+  redirectUri: ${REDIRECT_URL:http://localhost:5173}
 
 server:
   tomcat:


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #134 

## 📝 작업 내용
- 토큰 검증 및 재발급 로직 구조 개선
- 회원 등록 상태에 따른 접근 제어 로직 명확화
- 예외 처리 및 오류 응답 로직 리팩토링
- 코드 가독성 및 유지보수성 향상

## 🎸 기타 (선택)
 - `TokenAuthenticationFilter` 클래스가 담당하는 역할이 많은 것 같아 추후 리랙터링이 필요해 보입니다.
