### PR TITLE
refactor: 회원 상태 기반 리다이렉트 URL 결정 로직을 Member 도메인으로 이동 (#139)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -64,10 +64,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             response, REFRESH_TOKEN_COOKIE_NAME, refreshToken, refreshTokenDuration.toSeconds()
         );
 
-        String targetUrl = redirectUrl;
-        if (!member.registrationCompleted()) {
-            targetUrl = redirectUrl + "?status=NEED_MORE_INFO";
-        }
+        String targetUrl = member.getRedirectUrlByStatus(redirectUrl);
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/domain/Member.java
@@ -106,4 +106,12 @@ public class Member extends BaseEntity {
     public void updateNickname(String nickName) {
         this.nickname = nickName;
     }
+
+    public String getRedirectUrlByStatus(String baseUrl) {
+        if (!this.registrationCompleted()) {
+            return baseUrl + "?status=NEED_MORE_INFO";
+        }
+
+        return baseUrl;
+    }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #139 

## 📝 작업 내용
- Member 엔티티에 `getRedirectUrlByStatus` 메서드 추가
- 상태에 따라 등록 필요 여부를 URL 파라미터로 추가하는 로직 구현

## 🎸 기타 (선택)
- 현재 Member 엔티티를 도메인 객체와 같이 사용하고 있는데, 추후 둘(`엔티티`, `도메인`)의 역할에 따라 분리할 필요가 있을 것 같습니다.

## 💬 리뷰 요구사항(선택)
