### PR TITLE
fix: 인터뷰 시작 시 중복된 질문이 반환되는 현상 해결 (#143)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/interview/service/InterviewStartService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/interview/service/InterviewStartService.java
@@ -1,5 +1,7 @@
 package com.blooming.inpeak.interview.service;
 
+import com.blooming.inpeak.common.error.exception.BadRequestException;
+import com.blooming.inpeak.common.error.exception.NotFoundException;
 import com.blooming.inpeak.interview.dto.response.InterviewStartResponse;
 import com.blooming.inpeak.member.domain.InterestType;
 import com.blooming.inpeak.member.service.MemberInterestService;
@@ -24,7 +26,7 @@ public class InterviewStartService {
         // 남은 모의면접 횟수 확인
         int interviewCount = interviewService.getRemainingInterviews(memberId, startDate).count();
         if (interviewCount == 0) {
-            throw new RuntimeException("남은 모의면접 횟수가 없습니다.");
+            throw new BadRequestException("모의면접 횟수가 모두 소진되었습니다.");
         }
 
         // 인터뷰 생성
@@ -32,6 +34,10 @@ public class InterviewStartService {
 
         // 사용자의 관심사를 가져와 질문을 필터링
         List<InterestType> interestTypes = memberInterestService.getMemberInterestTypes(memberId);
+        if (interestTypes.isEmpty()) {
+            throw new NotFoundException("관심사가 선택되지 않았습니다.");
+        }
+
         List<QuestionResponse> questionResponse = questionService.getFilteredQuestions(memberId, interestTypes);
 
         return InterviewStartResponse.of(interviewId, questionResponse);

--- a/inpeak/src/main/java/com/blooming/inpeak/question/repository/QuestionRepository.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/question/repository/QuestionRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query(value = """
-        SELECT q.*
+        SELECT DISTINCT q.*
         FROM questions q
         LEFT JOIN answers a ON q.id = a.question_id AND a.member_id = :memberId
         WHERE q.type IN (:types)

--- a/inpeak/src/test/java/com/blooming/inpeak/interview/service/InterviewStartServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/interview/service/InterviewStartServiceTest.java
@@ -3,6 +3,7 @@ package com.blooming.inpeak.interview.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.blooming.inpeak.common.error.exception.BadRequestException;
 import com.blooming.inpeak.interview.domain.Interview;
 import com.blooming.inpeak.interview.dto.response.InterviewStartResponse;
 import com.blooming.inpeak.interview.repository.InterviewRepository;
@@ -75,7 +76,7 @@ class InterviewStartServiceTest extends IntegrationTestSupport {
         // when & then
         assertThatThrownBy(() ->
             interviewStartService.startInterview(MEMBER_ID, TODAY)
-        ).isInstanceOf(RuntimeException.class)
-            .hasMessageContaining("남은 모의면접 횟수가 없습니다.");
+        ).isInstanceOf(BadRequestException.class)
+            .hasMessageContaining("모의면접 횟수가 모두 소진되었습니다.");
     }
 }

--- a/inpeak/src/test/java/com/blooming/inpeak/question/service/QuestionServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/question/service/QuestionServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("QuestionService 테스트")
 public class QuestionServiceTest extends IntegrationTestSupport {
@@ -44,6 +45,7 @@ public class QuestionServiceTest extends IntegrationTestSupport {
     }
 
     @Test
+    @Transactional
     @DisplayName("회원 관심사에 따른 질문 조회 시, 이미 이해한 질문은 제외하고 최대 3개만 반환해야 한다.")
     void getFilteredQuestions_excludesUnderstoodQuestions_andReturnsUpTo3() {
         // given
@@ -94,5 +96,68 @@ public class QuestionServiceTest extends IntegrationTestSupport {
         List<Long> resultIds = result.stream().map(QuestionResponse::id).toList();
         assertThat(resultIds).isSubsetOf(q2.getId(), q4.getId(), q5.getId(), q6.getId());
         assertThat(resultIds).doesNotContain(q1.getId(), q3.getId());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("회원 관심사에 따른 질문 조회 시, 조건을 만족하는 질문이 3개 미만이면 해당 개수만큼 반환해야 한다.")
+    void getFilteredQuestions_returnsLessThan3IfAvailableQuestionsAreLess() {
+        // given
+        List<InterestType> interestTypes = List.of(InterestType.REACT);
+
+        Question q1 = questionRepository.save(
+            Question.of("React 질문", QuestionType.REACT, "리액트 정답"));
+        Question q2 = questionRepository.save(
+            Question.of("React 질문", QuestionType.REACT, "리액트 정답"));
+        Question q3 = questionRepository.save(
+            Question.of("React 질문", QuestionType.REACT, "리액트 정답"));
+        Question q4 = questionRepository.save(
+            Question.of("React 질문", QuestionType.REACT, "리액트 정답"));
+        Question q5 = questionRepository.save(
+            Question.of("React 질문", QuestionType.REACT, "리액트 정답"));
+
+        answerRepository.save(
+            Answer.builder()
+                .questionId(q1.getId())
+                .memberId(MEMBER_ID)
+                .interviewId(interviewId)
+                .userAnswer("리액트 답변")
+                .isUnderstood(true) // 이해함
+                .status(AnswerStatus.CORRECT)
+                .build()
+        );
+
+        answerRepository.save(
+            Answer.builder()
+                .questionId(q2.getId())
+                .memberId(MEMBER_ID)
+                .interviewId(interviewId)
+                .userAnswer("리액트 답변")
+                .isUnderstood(true) // 이해함
+                .status(AnswerStatus.CORRECT)
+                .build()
+        );
+
+        answerRepository.save(
+            Answer.builder()
+                .questionId(q3.getId())
+                .memberId(MEMBER_ID)
+                .interviewId(interviewId)
+                .userAnswer("리액트 답변")
+                .isUnderstood(true) // 이해함
+                .status(AnswerStatus.CORRECT)
+                .build()
+        );
+
+        // when
+        List<QuestionResponse> result =
+            questionService.getFilteredQuestions(MEMBER_ID, interestTypes);
+
+        // then
+        assertThat(result).hasSize(2); // q4, q5만 나와야 함
+
+        List<Long> resultIds = result.stream().map(QuestionResponse::id).toList();
+        assertThat(resultIds).contains(q4.getId(), q5.getId());
+        assertThat(resultIds).doesNotContain(q1.getId(), q2.getId(), q3.getId());
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈

* close #143 

## 📝 작업 내용

* 동일한 question에 대해 여러 answer가 존재하는 경우, 
`LEFT JOIN`으로 인해 answers의 개수만큼 question이 복제되는 문제가 발생했습니다.
* `SELECT`절에 `DISTINCT`를 적용하여 중복된 question row를 제거했습니다.
* `InterviewStartService`의 `RuntimeException`을 알맞는 커스텀 Exception으로 변경하였습니다.
* `QuestionService` 테스트 코드를 추가하였습니다.


## 🎸 기타 (선택)
> 

## 💬 리뷰 요구사항(선택)

> 
