### PR TITLE
fix: video_url 저장 시 쿼리 파라미터 제거 (#145)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
@@ -116,13 +116,14 @@ public class Answer extends BaseEntity {
         String userAnswer = texts[0];
         AnswerStatus status = AnswerStatus.valueOf(texts[1]);
         String AIAnswer = texts[2];
+        String trimmedVideoURL = removeQueryParams(command.videoURL());
 
         return Answer.builder()
             .questionId(command.questionId())
             .memberId(command.memberId())
             .interviewId(command.interviewId())
             .userAnswer(userAnswer)
-            .videoURL(command.videoURL())
+            .videoURL(trimmedVideoURL)
             .runningTime(command.time())
             .isUnderstood(false)
             .status(status)
@@ -134,6 +135,11 @@ public class Answer extends BaseEntity {
         return Arrays.stream(feedback.split("@"))
             .map(String::trim) // 각 문자열에 trim 적용
             .toArray(String[]::new);
+    }
+
+    private static String removeQueryParams(String url) {
+        if (url == null) return null;
+        return url.split("\\?")[0];
     }
 
     /**

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerPresignedUrlService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerPresignedUrlService.java
@@ -1,6 +1,7 @@
 package com.blooming.inpeak.answer.service;
 
 import com.blooming.inpeak.answer.dto.response.AnswerPresignedUrlResponse;
+import com.blooming.inpeak.common.error.exception.BadRequestException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -79,7 +80,7 @@ public class AnswerPresignedUrlService {
     private String generateObjectKey(Long memberId, LocalDate startDate, String extension) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMdd");
         String dateString = startDate.format(formatter);
-        String uuid = UUID.randomUUID().toString();
+        String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 10);
         return String.format("videos/%d/%s/%s.%s", memberId, dateString, uuid, extension);
     }
 
@@ -93,7 +94,7 @@ public class AnswerPresignedUrlService {
         String lowerExt = extension.toLowerCase();
 
         if (!EXT_TO_CONTENT_TYPE.containsKey(lowerExt)) {
-            throw new RuntimeException("지원하지 않는 파일 형식입니다.");
+            throw new BadRequestException("지원하지 않는 파일 형식입니다.");
         }
 
         return EXT_TO_CONTENT_TYPE.getOrDefault(lowerExt, "application/octet-stream");


### PR DESCRIPTION
## ⚡️ 관련 이슈

* close #145 

## 📝 작업 내용

* S3 Object Key 생성 시 UUID를 10글자만 사용하도록 변경하여 전체 경로 길이를 단축했습니다.
* `video_url` 필드 저장 시 `?` 기준으로 query string을 제거한 정적 URL만 저장되도록 수정했습니다.
* `AnswerPresignedUrlService`의 `RuntimeException`을 알맞는 커스텀 Exception으로 변경하였습니다.

## 🎸 기타 (선택)
> 

## 💬 리뷰 요구사항(선택)

> 
