### PR TITLE
fix: findAllVideoUrlsByMemberId 쿼리 수정 (#157)

### DIFF
--- a/inpeak/src/main/java/com/blooming/inpeak/answer/repository/AnswerRepository.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/repository/AnswerRepository.java
@@ -85,7 +85,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     /**
      * 특정 멤버의 모든 비디오 URL 조회
      */
-    @Query(value = "SELECT video_url FROM answer WHERE member_id = :memberId", nativeQuery = true)
+    @Query(value = "SELECT video_url FROM answers WHERE member_id = :memberId", nativeQuery = true)
     List<String> findAllVideoUrlsByMemberId(@Param("memberId") Long memberId);
 
     Optional<Answer> findByInterviewIdAndQuestionId(Long interviewId, Long questionId);


### PR DESCRIPTION
## ⚡️ 관련 이슈

* close #157 

## 📝 작업 내용

> `AnswerRepository.findAllVideoUrlsByMemberId()` 메서드의 쿼리를 수정했습니다.

## 🎸 기타 (선택)

## 💬 리뷰 요구사항(선택)

