### PR TITLE
refatcor: MemberStatistics 로직 이전 및 쿼리 개선 (#160)

### DIFF
--- a/inpeak/init-scripts/01-ddl.sql
+++ b/inpeak/init-scripts/01-ddl.sql
@@ -92,7 +92,6 @@ CREATE TABLE member_statistics (
                                     correct_count INT NOT NULL DEFAULT 0,
                                     incorrect_count INT NOT NULL DEFAULT 0,
                                     skipped_count INT NOT NULL DEFAULT 0,
-                                    total_count INT GENERATED ALWAYS AS (correct_count + incorrect_count + skipped_count) STORED,
                                     created_at TIMESTAMP NOT NULL,
                                     updated_at TIMESTAMP NOT NULL
 );

--- a/inpeak/src/main/java/com/blooming/inpeak/common/utils/LoggingAspect.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/common/utils/LoggingAspect.java
@@ -39,7 +39,7 @@ public class LoggingAspect {
             logger.info("[종료] 메서드: {} | 실행 시간: {}ms | 반환값: {}", methodName, elapsedTime, result);
             return result;
         } catch (Exception e) {
-            logger.error("[오류] 메서드: {} | 예외 발생: {}", methodName, e.getMessage(), e);
+            logger.error("[오류] 메서드: {} | 예외 발생: {}", methodName, e.getMessage());
             throw e;
         }
     }

--- a/inpeak/src/main/java/com/blooming/inpeak/member/repository/MemberStatisticsRepository.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/member/repository/MemberStatisticsRepository.java
@@ -15,8 +15,8 @@ public interface MemberStatisticsRepository extends JpaRepository<MemberStatisti
      */
     @Query("""
         SELECT COALESCE(
-            CAST(ms.correctCount * 100 AS INTEGER) / 
-            NULLIF(CAST(ms.correctCount + ms.incorrectCount + ms.skippedCount AS INTEGER), 0),
+            ms.correctCount * 100 /
+            NULLIF(ms.correctCount + ms.incorrectCount + ms.skippedCount, 0),
             0)
         FROM MemberStatistics ms
         WHERE ms.memberId = :memberId
@@ -28,8 +28,8 @@ public interface MemberStatisticsRepository extends JpaRepository<MemberStatisti
      */
     @Query("""
         SELECT COALESCE(
-            CAST(SUM(ms.correctCount) * 100 AS INTEGER) / 
-            NULLIF(CAST(SUM(ms.correctCount + ms.incorrectCount + ms.skippedCount) AS INTEGER), 0),
+            SUM(ms.correctCount) * 100 /
+            NULLIF(SUM(ms.correctCount + ms.incorrectCount + ms.skippedCount), 0),
             0)
         FROM MemberStatistics ms
     """)

--- a/inpeak/src/test/java/com/blooming/inpeak/member/service/MemberStatisticsServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/member/service/MemberStatisticsServiceTest.java
@@ -3,6 +3,8 @@ package com.blooming.inpeak.member.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.blooming.inpeak.member.domain.MemberStatistics;
+import com.blooming.inpeak.member.dto.response.MemberStatsResponse;
+import com.blooming.inpeak.member.dto.response.SuccessRateResponse;
 import com.blooming.inpeak.member.repository.MemberStatisticsRepository;
 import com.blooming.inpeak.member.dto.response.MemberLevelResponse;
 import com.blooming.inpeak.support.IntegrationTestSupport;
@@ -21,10 +23,11 @@ public class MemberStatisticsServiceTest extends IntegrationTestSupport {
     private MemberStatisticsRepository memberStatisticsRepository;
 
     private final Long memberId = 1L;
+    private final Long otherMemberId = 2L;
 
-    @DisplayName("getMemberLevel()은 경험치가 0일 때 올바른 레벨 정보를 반환해야 한다.")
-    @Transactional
     @Test
+    @Transactional
+    @DisplayName("getMemberLevel()은 경험치가 0일 때 올바른 레벨 정보를 반환해야 한다.")
     void getMemberLevel_ShouldReturnLevelInformation_WhenExpIsZero() {
         // given
         memberStatisticsRepository.save(MemberStatistics.of(memberId));
@@ -38,9 +41,9 @@ public class MemberStatisticsServiceTest extends IntegrationTestSupport {
         assertThat(response.nextExp()).isEqualTo(0);
     }
 
-    @DisplayName("getMemberLevel()은 경험치 40일 때 올바른 레벨 정보를 반환해야 한다.")
-    @Transactional
     @Test
+    @Transactional
+    @DisplayName("getMemberLevel()은 경험치 40일 때 올바른 레벨 정보를 반환해야 한다.")
     void getMemberLevel_ShouldReturnCorrectLevelInformation_WhenExpIs40() {
         // given
         MemberStatistics stat = memberStatisticsRepository.save(MemberStatistics.of(memberId));
@@ -59,9 +62,9 @@ public class MemberStatisticsServiceTest extends IntegrationTestSupport {
         assertThat(response.nextExp()).isEqualTo(60);
     }
 
-    @DisplayName("getMemberLevel()은 경험치가 1350을 초과하면 최대 레벨과 올바른 경험치 정보를 반환해야 한다.")
-    @Transactional
     @Test
+    @Transactional
+    @DisplayName("getMemberLevel()은 경험치가 1350을 초과하면 최대 레벨과 올바른 경험치 정보를 반환해야 한다.")
     void getMemberLevel_ShouldReturnMaxLevel_WhenExpExceeds1350() {
         // given
         MemberStatistics stat = memberStatisticsRepository.save(MemberStatistics.of(memberId));
@@ -78,5 +81,123 @@ public class MemberStatisticsServiceTest extends IntegrationTestSupport {
         assertThat(response.level()).isEqualTo(10);
         assertThat(response.currentExp()).isEqualTo(5);
         assertThat(response.nextExp()).isEqualTo(0);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("getSuccessRate()은 특정 회원 및 전체 통계가 없는 경우, 성공률은 모두 0이어야 한다.")
+    void getSuccessRate_ShouldReturnZero_IfNoStatisticsExist() {
+        // given
+        memberStatisticsRepository.save(MemberStatistics.of(memberId));
+
+        // when
+        SuccessRateResponse response = memberStatisticsService.getSuccessRate(memberId);
+
+        // then
+        assertThat(response.userSuccessRate()).isEqualTo(0);
+        assertThat(response.averageSuccessRate()).isEqualTo(0);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("getSuccessRate()은 전체 통계는 있지만 특정 회원 통계가 없는 경우, 회원 성공률만 0이어야 한다.")
+    void getSuccessRate_ShouldReturnZero_IfNoMemberStatistics() {
+        // given
+        memberStatisticsRepository.save(MemberStatistics.of(memberId));
+        MemberStatistics otherStat = memberStatisticsRepository.save(MemberStatistics.of(otherMemberId));
+
+        otherStat.increaseCorrect();
+        otherStat.increaseIncorrect();
+        otherStat.increaseSkipped();
+
+        // when
+        SuccessRateResponse response = memberStatisticsService.getSuccessRate(memberId);
+
+        // then
+        assertThat(response.userSuccessRate()).isEqualTo(0);
+        assertThat(response.averageSuccessRate()).isEqualTo(33);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("getSuccessRate()은 특정 회원 통계만 존재하는 경우, 특정 회원 및 전체 성공률은 동일해야 한다.")
+    void getSuccessRate_ShouldReturnSameRates_IfOnlyOneMemberExists() {
+        // given
+        MemberStatistics stat = memberStatisticsRepository.save(MemberStatistics.of(memberId));
+
+        stat.increaseCorrect();
+        stat.increaseSkipped();
+
+        // when
+        SuccessRateResponse response = memberStatisticsService.getSuccessRate(memberId);
+
+        // then
+        assertThat(response.userSuccessRate()).isEqualTo(50);
+        assertThat(response.averageSuccessRate()).isEqualTo(response.userSuccessRate());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("getSuccessRate()은 특정 회원과 다른 회원들의 통계가 존재하는 경우, 각 성공률은 정확히 계산되어야 한다.")
+    void getSuccessRate_ShouldReturnCorrectRates_IfMultipleUsersExist() {
+        // given
+        MemberStatistics stat = memberStatisticsRepository.save(MemberStatistics.of(memberId));
+        MemberStatistics otherStat = memberStatisticsRepository.save(MemberStatistics.of(otherMemberId));
+
+        // 해당 회원 성공률 33
+        stat.increaseCorrect();
+        stat.increaseIncorrect();
+        stat.increaseSkipped();
+
+        // 전체 회원 성공률 50
+        otherStat.increaseCorrect();
+
+        // when
+        SuccessRateResponse response = memberStatisticsService.getSuccessRate(memberId);
+
+        // then
+        assertThat(response.userSuccessRate()).isEqualTo(33);
+        assertThat(response.averageSuccessRate()).isEqualTo(50);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("getMemberStats()는 특정 회원의 통계가 없는 경우 모두 0을 반환해야 한다.")
+    void getMemberStats_ShouldReturnZero_IfNoMemberStatistics() {
+        //given
+        memberStatisticsRepository.save(MemberStatistics.of(memberId));
+
+        //when
+        MemberStatsResponse response = memberStatisticsService.getMemberStats(memberId);
+
+        //then
+        assertThat(response.totalAnswerCount()).isEqualTo(0);
+        assertThat(response.correctAnswerCount()).isEqualTo(0);
+        assertThat(response.incorrectAnswerCount()).isEqualTo(0);
+        assertThat(response.skippedAnswerCount()).isEqualTo(0);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("getMemberStats()는 특정 회원의 정확한 통계 정보를 반환해야 한다.")
+    void getMemberStats_ShouldReturnCorrectStats_IfMemberStatsExist() {
+        //given
+        MemberStatistics stat = memberStatisticsRepository.save(MemberStatistics.of(memberId));
+
+        stat.increaseCorrect();
+        stat.increaseCorrect();
+        stat.increaseCorrect();
+        stat.increaseIncorrect();
+        stat.increaseIncorrect();
+        stat.increaseSkipped();
+
+        //when
+        MemberStatsResponse response = memberStatisticsService.getMemberStats(memberId);
+
+        //then
+        assertThat(response.totalAnswerCount()).isEqualTo(6);
+        assertThat(response.correctAnswerCount()).isEqualTo(3);
+        assertThat(response.incorrectAnswerCount()).isEqualTo(2);
+        assertThat(response.skippedAnswerCount()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈

- close #160 

## 📝 작업 내용

- `MemberStatistics.totalCount` 필드 제거
- 답변 성공률 쿼리 개선
- 회원 레벨 계산 로직을 서비스에서 도메인으로 이동
- `MemberStatisticsService` 테스트 작성
- `LoggingAspect`에서 스택 트레이스 출력 제거

## 🎸 기타 (선택)


## 💬 리뷰 요구사항(선택)


