### PR TITLE
Fix/#168 통계 누락 수정 및 비동기 답변 처리 prod 환경 대응

### DIFF
--- a/.github/workflows/inpeak-ci.yml
+++ b/.github/workflows/inpeak-ci.yml
@@ -42,6 +42,13 @@ jobs:
           mkdir -p ./src/main/resources
           echo "${{ secrets.APPLICATION_OPENAI_YML }}" > ./src/main/resources/application-openai.yml
 
+      - name: Kafka 컨테이너 실행
+        run: docker compose -f docker-compose-kafka.yml up -d
+        working-directory: ./inpeak
+
+      - name: Kafka 시작 대기 (5초)
+        run: sleep 5
+
 
       - name: Gradlew Wrapper 실행 권한 부여
         run: chmod +x gradlew

--- a/inpeak/docker-compose-kafka.yml
+++ b/inpeak/docker-compose-kafka.yml
@@ -1,0 +1,26 @@
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    ports:
+      - "2181:2181"
+    networks:
+      - inpeak-net
+
+  kafka:
+    image: wurstmeister/kafka:latest
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+    depends_on:
+      - zookeeper
+    networks:
+      - inpeak-net
+
+networks:
+  inpeak-net:

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/domain/Answer.java
@@ -16,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -132,7 +133,7 @@ public class Answer extends BaseEntity {
     }
 
     private static String[] splitAndTrimText(String feedback) {
-        return Arrays.stream(feedback.split("@"))
+        return Arrays.stream(feedback.split(Pattern.quote("@$")))
             .map(String::trim) // 각 문자열에 trim 적용
             .toArray(String[]::new);
     }

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerPresignedUrlService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerPresignedUrlService.java
@@ -30,8 +30,6 @@ public class AnswerPresignedUrlService {
     private final RestTemplate simpleRestTemplate;
 
     private static final Map<String, String> EXT_TO_CONTENT_TYPE = Map.of(
-        "mp4", "video/mp4",
-        "mov", "video/quicktime",
         "webm", "video/webm",
         "wav", "audio/wav"
     );

--- a/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
+++ b/inpeak/src/main/java/com/blooming/inpeak/answer/service/AnswerService.java
@@ -22,6 +22,7 @@ import com.blooming.inpeak.common.error.exception.ForbiddenException;
 import com.blooming.inpeak.common.error.exception.NotFoundException;
 import com.blooming.inpeak.interview.domain.Interview;
 import com.blooming.inpeak.interview.repository.InterviewRepository;
+import com.blooming.inpeak.member.service.MemberStatisticsService;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,7 @@ public class AnswerService {
     private final InterviewRepository interviewRepository;
     private final AnswerPresignedUrlService answerPresignedUrlService;
     private final AnswerTaskRepository answerTaskRepository;
+    private final MemberStatisticsService memberStatisticsService;
 
     /**
      * 답변을 스킵하는 메서드
@@ -59,6 +61,9 @@ public class AnswerService {
 
         Answer skippedAnswer = Answer.ofSkipped(memberId, questionId, interviewId);
         answerRepository.save(skippedAnswer);
+
+        // 회원 통계 업데이트
+        memberStatisticsService.updateStatistics(memberId, skippedAnswer.getStatus());
 
         return new AnswerIDResponse(skippedAnswer.getId());
     }

--- a/inpeak/src/main/resources/application.yml
+++ b/inpeak/src/main/resources/application.yml
@@ -124,3 +124,16 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: answer-task-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.trusted.packages: com.blooming.inpeak.answer.dto.command

--- a/inpeak/src/test/java/com/blooming/inpeak/answer/service/AnswerServiceTest.java
+++ b/inpeak/src/test/java/com/blooming/inpeak/answer/service/AnswerServiceTest.java
@@ -18,6 +18,8 @@ import com.blooming.inpeak.answer.repository.AnswerTaskRepository;
 import com.blooming.inpeak.common.error.exception.NotFoundException;
 import com.blooming.inpeak.interview.domain.Interview;
 import com.blooming.inpeak.interview.repository.InterviewRepository;
+import com.blooming.inpeak.member.domain.MemberStatistics;
+import com.blooming.inpeak.member.repository.MemberStatisticsRepository;
 import com.blooming.inpeak.question.domain.Question;
 import com.blooming.inpeak.question.domain.QuestionType;
 import com.blooming.inpeak.question.repository.QuestionRepository;
@@ -51,6 +53,9 @@ class AnswerServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private AnswerService answerService;
+
+    @Autowired
+    private MemberStatisticsRepository memberStatisticsRepository;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -137,6 +142,8 @@ class AnswerServiceTest extends IntegrationTestSupport {
     @Test
     void skipAnswer_ShouldSaveSkippedAnswer() {
         // given
+        memberStatisticsRepository.save(MemberStatistics.of(memberId));
+
         Long interviewId = interviewRepository.save(Interview.of(memberId, LocalDate.now()))
             .getId();
         Question question = questionRepository.save(


### PR DESCRIPTION
## ⚡️ 관련 이슈

- close #168 

## 📝 작업 내용

- 스킵된 답변 생성 메서드에 회원 통계 업데이트 로직을 추가하였습니다.
- prod 환경에서 비동기 답변 처리 문제를 수정했습니다.
  - `docker-compose-kafka.yml` 추가
  - `application.yml`-`prod` profile에 kafka 설정 추가
  - `Answer` 도메인 로직 수정

## 🎸 기타 (선택)


## 💬 리뷰 요구사항(선택)
